### PR TITLE
fix:  README typo; add Nvidia GPU troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _Physical AI for Warehouse Robotics_
 The demonstration features a fully autonomous warehouse robot capable of perception, reasoning, and natural language understanding. It performs warehouse tasks based on human commands, detects anomalies such as spills or blocked paths, and responds appropriately to maintain safety and efficiency.
 
 It is the first demo of agentic embodied AI running fully on board of a portable compute platform (**AMD Ryzen™ AI**).
-The demo illustrates agentic approach to physical intelligence, where agents orchestrate a typical robot manipulation and navigation stack. Compared to dedicated robot foundation models, this approach retains steate of the art robotic software in low-level-control, and is low cost due to use of off-shelf general models and fine-tuning with simulation.
+The demo illustrates agentic approach to physical intelligence, where agents orchestrate a typical robot manipulation and navigation stack. Compared to dedicated robot foundation models, this approach retains state of the art robotic software in low-level-control, and is low cost due to use of off-shelf general models and fine-tuning with simulation.
 
 See more in the demo video:
 

--- a/docker/compose.amd.yaml
+++ b/docker/compose.amd.yaml
@@ -91,6 +91,12 @@ services:
     build:
       dockerfile: Dockerfile.llama
     command: -m /custom_ggufs/Qwen3-Embedding-0.6b_BF16.gguf --embedding -c 4096 -b 2048 -ub 2048 --pooling last --port 8082 --host 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:8082/ | grep -q 200 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     networks:
       - ros2_bridge
 
@@ -99,6 +105,12 @@ services:
     build:
       dockerfile: Dockerfile.llama
     command: -m /custom_ggufs/Qwen3-Reranker-0.6B_16BF.gguf --embedding --pooling rank -fa on -c 4096 -b 2048 -ub 2048 --port 8083 --host 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:8083/ | grep -q 200 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     networks:
       - ros2_bridge
 networks:

--- a/docker/compose.nvidia.yaml
+++ b/docker/compose.nvidia.yaml
@@ -110,6 +110,12 @@ services:
     build:
       dockerfile: Dockerfile.llama
     command: -m /custom_ggufs/Qwen3-Embedding-0.6b_BF16.gguf --embedding -c 4096 -b 2048 -ub 2048 --pooling last --port 8082 --host 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:8082/ | grep -q 200 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     networks:
       - ros2_bridge
 
@@ -118,6 +124,12 @@ services:
     build:
       dockerfile: Dockerfile.llama
     command: -m /custom_ggufs/Qwen3-Reranker-0.6B_16BF.gguf --embedding --pooling rank -fa on -c 4096 -b 2048 -ub 2048 --port 8083 --host 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:8083/ | grep -q 200 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     networks:
       - ros2_bridge
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,7 +62,20 @@ docker compose -f docker/compose.nvidia.yaml up
 
 ## Troubleshooting
 
-- **O3DE Doesn't start**: Ensure you have the correct GPU drivers and container toolkit installed. Run `docker compose -f docker/compose.***.yaml up sim` to see the logs.
+- **O3DE Doesn't start**: Ensure you have the correct GPU drivers and container toolkit installed. Run `docker compose -f docker/compose.***.yaml up sim` to see the logs. If logs show `llvmpipe` (software rendering) instead of your NVIDIA GPU, verify NVIDIA Container Toolkit is working:
+
+  1. Check your CUDA version: `nvidia-smi` (look for "CUDA Version")
+  2. Test GPU access: `docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu24.04 nvidia-smi` (adjust Ubuntu version and CUDA version to match your system if needed)
+  3. If this fails, configure the toolkit: `sudo nvidia-ctk runtime configure --runtime=docker` and restart Docker daemon: `sudo systemctl restart docker`
+  4. Note: Snap Docker is incompatible with NVIDIA Container Toolkit due to sandboxing. If using snap Docker, uninstall it (`sudo snap remove --purge docker`) and install official Docker from https://get.docker.com instead.
+
+  Example of llvmpipe (software rendering) detection in logs:
+
+  ```
+  RHISystem:     Enumerated physical device: llvmpipe (LLVM 20.1.2, 256 bits)
+  RHISystem:     Using physical device: llvmpipe (LLVM 20.1.2, 256 bits)
+  ```
+
 - **Display Issues**: If windows don't appear, ensure you ran `xhost +local:docker` and that your `DISPLAY` environment variable is set correctly (`echo $DISPLAY`).
 - **GPU Access**: If the simulation runs slowly or crashes, check your GPU drivers and container toolkit installation.
 - **AMD GPU Access**: Ensure you have passed the correct devices. For more details on running ROCm Docker containers, see the [official AMD documentation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html).


### PR DESCRIPTION
**Main Changes** 
- Corrected a typo in README.md
- Added more details for troubleshooting O3DE start failure on Nvidia GPU machine.
- Fixed the issue that `docker ps` showed llama containers' as unhealthy. Health checks were failing because the llama containers’ default check hit port 8080, while the servers run on 8082 (embeddings) and 8083 (reranker). The fix is to add explicit health checks in docker/compose.*.yaml that curl the correct ports. 

```
$ docker ps 
CONTAINER ID   IMAGE                                             COMMAND                  CREATED          STATUS                      PORTS     NAMES
...
0f4a4f8ebe7d   robotecai/mobile-manipulator-demo-llama:latest    "/app/llama-server -…"   19 minutes ago   Up 19 minutes (unhealthy)             docker-safety-reranker-1
f503cef71580   robotecai/mobile-manipulator-demo-llama:latest    "/app/llama-server -…"   19 minutes ago   Up 19 minutes (unhealthy)             docker-safety-embeddings-1
```
 
**Testing**
Following ran along with `docker ps`. 
```
docker compose -f docker/compose.nvidia.yaml up
```