### PR TITLE
feat: add pixi task runner to replace manual setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ safety_violations.json
 imgui.ini
 anomaly_images/
 package_condition_images/
+models/

--- a/config.toml
+++ b/config.toml
@@ -42,10 +42,3 @@ embeddings_base_url = "http://localhost:8082/v1"
 # NOTE: The reranker and the embedding model are two separate models!
 reranker_base_url = "http://localhost:8083/v1/reranking"
 
-# INFO:
-# Start the EMBEDDING model in llama.cpp using the following command:
-# ./llama-server -m /home/user/llamas/gguf/custom_ggufs/Qwen3-Embedding-0.6b_Q8_0.gguf --embedding --pooling last -c 4096 -b 2048 -ub 2048 --port 8082
-
-# INFO:
-# Start the RERANKER model in llama.cpp using the following command:
-# ./llama-server -m /home/user/llamas/gguf/custom_ggufs/Qwen3-Reranker-0.6B_BF16.gguf --embedding --pooling rank -c 4096  -b 2048 -ub 2048 --port 8083

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,65 +1,54 @@
 # Running the Demo
 
+All commands use `pixi run` — the ROS 2 workspace is sourced automatically via `pixi_activate.sh`.
+
+Run `pixi task list` to see all available commands.
+
 ## O3DE
 
-To run the O3DE, run the following command:
-
 ```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-${DEMO_ROOT}/sim/build/linux/bin/profile/MobileManipulatorDemo.GameLauncher
+pixi run sim
 ```
 
 ## ROS 2
 
-To run the ROS 2 stack and control agents, execute:
-
 ```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-./scripts/run_ros2_stack.sh
+pixi run ros2
 ```
 
 ## HMI
 
-To run the HMI, execute:
-
 ```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-ros2 launch mobile_manipulator_hmi hmi_launch.py
+pixi run hmi
 ```
 
 # Inference
 
-To run the inference, execute:
+## Local (llama.cpp)
+
+Models default to `$DEMO_ROOT/models/<filename>`. Override with env vars if your models are elsewhere.
 
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -hf <model/s selected in `config.toml`> <args>
+# GPT-OSS-20B — port 8080
+pixi run serve-llm
+
+# LFM2-VL-3B — port 8081
+pixi run serve-vlm
+
+# Qwen3-Embedding-0.6b — port 8082
+pixi run serve-embedding
+
+# Qwen3-Reranker-0.6B — port 8083
+pixi run serve-reranker
 ```
 
-For example, use the following commands to start each of the models. Note that the extra arguments
-are required for a stable operation of the Demo:
-
-- GPT-OSS-20B
+To use a custom path:
 
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m /path/to/downloaded/model/unsloth_gpt-oss-20b-GGUF_gpt-oss-20b-Q4_K_M.gguf --no-prefill-assistant --port 8080
-```
-
-- LFM2-VL-3B-GGUF
-
-```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m /path/to/downloaded/model/LFM2-VL-3B_public/LFM2-VL-3B-Q8_0.gguf --mmproj /path/to/downloaded/model/mmproj-LFM2-VL-3B-Q8_0.gguf --port 8081
-```
-
-- Qwen3-Embedding-0.6b
-
-```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m /path/to/downloaded/model/Qwen3-Embedding-0.6b_Q8_0.gguf --embedding --pooling last -c 4096 -b 2048 -ub 2048 --port 8082
-```
-
-- Qwen3-Reranker-0.6B
-
-```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m /path/to/downloaded/model/Qwen3-Reranker-0.6B.gguf --embedding --pooling rank -c 4096  -b 2048 -ub 2048 --port 8083
+LLM_MODEL=/path/to/gpt-oss-20b-Q4_K_M.gguf pixi run serve-llm
+VLM_MODEL=/path/to/LFM2-VL-3B-Q8_0.gguf VLM_MMPROJ=/path/to/mmproj.gguf pixi run serve-vlm
+EMBEDDING_MODEL=/path/to/embedding.gguf pixi run serve-embedding
+RERANKER_MODEL=/path/to/reranker.gguf pixi run serve-reranker
 ```
 
 ## Agent
@@ -68,43 +57,29 @@ For instructions, see: [Agent setup and inference](../rai_app/README.md)
 
 ## Local Runtime Components
 
-These commands run the same components locally that are defined in `docker/compose.yaml`.
-Each command assumes you have sourced your ROS 2 environment:
-
-```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-```
-
-### Configuration Files
-
-- Local inference (default): `${DEMO_ROOT}/config.toml`
-
-### Individual ROS 2 Components
-
-Use these commands when you want to run components separately instead of `./scripts/run_ros2_stack.sh`:
-
-```shell
-ros2 launch robotec_kairos_ur10 robotec_launch.py
-ros2 run mobile_manipulator_hmi utilization_node
-uv run python rai_app/agents/nav2_agent.py
-uv run python rai_app/agents/moveit2_agent.py
-uv run python rai_app/environment/scene_agent.py
-ros2 run nav2_lifecycle_manager nav_lifecycle_node
-uv run python rai_app/agents/inspection_agent.py
-${DEMO_ROOT}/scripts/start_safety_agent.sh
-```
-
 ### Agent Orchestrator
 
 ```shell
-uv run python rai_app/agents/agent_orchestrator.py
+pixi run orchestrator
+```
+
+### Individual Components
+
+Use these when you want to run components separately instead of `pixi run ros2`:
+
+```shell
+pixi run nav2-agent
+pixi run moveit2-agent
+pixi run scene-agent
+pixi run inspection-agent
+pixi run safety-agent
 ```
 
 ### Safety Embeddings and Reranker (optional)
 
-These services are only required if you run the safety agent with RAG. See `docs/safety_agent_with_rag.md`.
+These are only required when running the safety agent with RAG. See `docs/safety_agent_with_rag.md`.
 
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m <embeddings_model.gguf> --embedding --pooling last --port 8082 --host 0.0.0.0
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m <reranker_model.gguf> --embedding --pooling rank -fa on --port 8083 --host 0.0.0.0
+EMBEDDING_MODEL=/path/to/embeddings.gguf pixi run serve-embedding
+RERANKER_MODEL=/path/to/reranker.gguf pixi run serve-reranker
 ```

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,9 +1,5 @@
 # Running the Demo
 
-All commands use `pixi run` — the ROS 2 workspace is sourced automatically via `pixi_activate.sh`.
-
-Run `pixi task list` to see all available commands.
-
 ## O3DE
 
 ```shell
@@ -22,9 +18,7 @@ pixi run ros2
 pixi run hmi
 ```
 
-# Inference
-
-## Local (llama.cpp)
+## Local inference (llama.cpp)
 
 Models default to `$DEMO_ROOT/models/<filename>`. Override with env vars if your models are elsewhere.
 
@@ -61,25 +55,4 @@ For instructions, see: [Agent setup and inference](../rai_app/README.md)
 
 ```shell
 pixi run orchestrator
-```
-
-### Individual Components
-
-Use these when you want to run components separately instead of `pixi run ros2`:
-
-```shell
-pixi run nav2-agent
-pixi run moveit2-agent
-pixi run scene-agent
-pixi run inspection-agent
-pixi run safety-agent
-```
-
-### Safety Embeddings and Reranker (optional)
-
-These are only required when running the safety agent with RAG. See `docs/safety_agent_with_rag.md`.
-
-```shell
-EMBEDDING_MODEL=/path/to/embeddings.gguf pixi run serve-embedding
-RERANKER_MODEL=/path/to/reranker.gguf pixi run serve-reranker
 ```

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,24 +1,32 @@
 # Running the Demo
 
-## O3DE
+## Run all at once
+
+```shell
+pixi run demo
+```
+
+## Run separately
+
+### O3DE
 
 ```shell
 pixi run sim
 ```
 
-## ROS 2
+### ROS 2
 
 ```shell
 pixi run ros2
 ```
 
-## HMI
+### HMI
 
 ```shell
 pixi run hmi
 ```
 
-## Local inference (llama.cpp)
+### Local inference (llama.cpp)
 
 Models default to `$DEMO_ROOT/models/<filename>`. Override with env vars if your models are elsewhere.
 
@@ -44,12 +52,6 @@ VLM_MODEL=/path/to/LFM2-VL-3B-Q8_0.gguf VLM_MMPROJ=/path/to/mmproj.gguf pixi run
 EMBEDDING_MODEL=/path/to/embedding.gguf pixi run serve-embedding
 RERANKER_MODEL=/path/to/reranker.gguf pixi run serve-reranker
 ```
-
-## Agent
-
-For instructions, see: [Agent setup and inference](../rai_app/README.md)
-
-## Local Runtime Components
 
 ### Agent Orchestrator
 

--- a/docs/running_hil_sim_hmi.md
+++ b/docs/running_hil_sim_hmi.md
@@ -1,105 +1,70 @@
 # Running a Demo on HIL, Simulation, and HMI
 
-## Simulation
+All commands use `pixi run` — the ROS 2 workspace is sourced automatically.
+
+## Simulation Machine
 
 ### O3DE
 
 ```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-${DEMO_ROOT}/sim/build/linux/bin/profile/MobileManipulatorDemo.GameLauncher
+pixi run sim
 ```
 
-## HIL
+## HIL Machine
 
 ### ROS 2
 
-To run the ROS 2 stack and control agents, execute:
-
 ```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-./scripts/run_ros2_stack.sh
+pixi run ros2
 ```
 
 ### Inference
 
-To run the inference, execute:
-
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -hf <model/s selected in `config.toml`>
+pixi run serve-llm        # GPT-OSS-20B       → port 8080
+pixi run serve-vlm        # LFM2-VL-3B        → port 8081
+pixi run serve-embedding  # Qwen3-Embedding   → port 8082
+pixi run serve-reranker   # Qwen3-Reranker    → port 8083
 ```
 
-e.g.
-
-````
-* GPT-OSS-20B
-```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m /path/to/downloaded/model/unsloth_gpt-oss-20b-GGUF_gpt-oss-20b-Q4_K_M.gguf --port 8080
-````
-
-- LFM2-VL-3B-GGUF
+Models default to `$DEMO_ROOT/models/<filename>`. Override with env vars if your models are elsewhere:
 
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m /path/to/downloaded/model/LFM2-VL-3B_public/LFM2-VL-3B-Q8_0.gguf --mmproj /path/to/downloaded/model/mmproj-LFM2-VL-3B-Q8_0.gguf --port 8081
+LLM_MODEL=/path/to/model.gguf pixi run serve-llm
+VLM_MODEL=/path/to/vlm.gguf VLM_MMPROJ=/path/to/mmproj.gguf pixi run serve-vlm
 ```
 
-- Qwen3-Embedding-0.6b
+### Agent Orchestrator
 
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m /path/to/downloaded/model/Qwen3-Embedding-0.6b_Q8_0.gguf --embedding --pooling last -c 4096 -b 2048 -ub 2048 --port 8082
+pixi run orchestrator
 ```
 
-- Qwen3-Reranker-0.6B
+## HMI Machine
 
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m /path/to/downloaded/model/Qwen3-Reranker-0.6B.gguf --embedding --pooling rank -c 4096  -b 2048 -ub 2048 --port 8083
+pixi run hmi
 ```
 
-## HMI
-
-### Running the GUI
-
-```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-ros2 launch mobile_manipulator_hmi hmi_launch.py
-```
-
-## Local Runtime Components
-
-These commands run the same components locally that are defined in `docker/compose.yaml`.
-Each command assumes you have sourced your ROS 2 environment:
-
-```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-```
-
-### Configuration Files
-
-- Local inference (default): `${DEMO_ROOT}/config.toml`
+---
 
 ## Individual ROS 2 Components
 
-Use these commands when you want to run components separately instead of `./scripts/run_ros2_stack.sh`:
+Use these when you want to run components separately instead of `pixi run ros2`:
 
 ```shell
-ros2 launch robotec_kairos_ur10 robotec_launch.py
-ros2 run mobile_manipulator_hmi utilization_node
-uv run python rai_app/agents/nav2_agent.py
-uv run python rai_app/agents/moveit2_agent.py
-uv run python rai_app/environment/scene_agent.py
-ros2 run nav2_lifecycle_manager nav_lifecycle_node
-uv run python rai_app/agents/inspection_agent.py
-${DEMO_ROOT}/scripts/start_safety_agent.sh
+pixi run nav2-agent
+pixi run moveit2-agent
+pixi run scene-agent
+pixi run inspection-agent
+pixi run safety-agent
 ```
-
-Start the orchestrator:
-
-For instructions, see: [Agent setup and inference](../rai_app/README.md)
 
 ## Safety Embeddings and Reranker (optional)
 
-These services are only required if you run the safety agent with RAG. See `docs/safety_agent_with_rag.md`.
+These are only required when running the safety agent with RAG. See `docs/safety_agent_with_rag.md`.
 
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m <embeddings_model.gguf> --embedding --pooling last --port 8082 --host 0.0.0.0
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-server -m <reranker_model.gguf> --embedding --pooling rank -fa on --port 8083 --host 0.0.0.0
+pixi run serve-embedding
+pixi run serve-reranker
 ```

--- a/docs/setup_hil.md
+++ b/docs/setup_hil.md
@@ -3,7 +3,7 @@
 This repository is compatible with the following system:
 
 - System: Ubuntu 24.04
-- ROS 2: Jazzy with development tools installed [link](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html#install-development-tools-optional)
+- ROS 2: Jazzy with development tools installed [link](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Real-Time-Kernel-Tuning-Guide.html)
 - Python: 3.12
 
 ## Building the Project
@@ -13,52 +13,52 @@ This repository is compatible with the following system:
 #### Clone the Repository
 
 ```shell
-cd /home/${USER}
 git clone git@github.com:RobotecAI/agentic-mobile-manipulator.git
+cd agentic-mobile-manipulator
 ```
 
-#### Set the Root Directory of the Project
+#### Install System Dependencies
 
-Set the root directory of the project to `$DEMO_ROOT` and `$O3DE_ROOT`, e.g., by adding the following line to your `.bashrc` or `.zshrc` file:
+```bash
+sudo apt update
+sudo apt install git git-lfs python3-vcstool
+```
+
+> [!NOTE]
+> ROS 2 Jazzy with dev tools (including `colcon`, `rosdep`) must also be installed.
+> See the [ROS 2 installation guide](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html#install-development-tools-optional).
+
+#### Install pixi
+
+[pixi](https://pixi.sh) orchestrates all build steps and sets environment variables automatically.
 
 ```shell
-export DEMO_ROOT=/home/${USER}/agentic-mobile-manipulator/
+curl -fsSL https://pixi.sh/install.sh | sh
 ```
 
-### Setup ROS 2
+Restart your shell or run `source ~/.bashrc` after installation.
 
-#### Build the ROS 2 Workspace
+---
+
+### Build
 
 ```shell
-cd ${DEMO_ROOT}/ros2_ws
-rosdep update
-rosdep install --ignore-src --from-paths src -y
-colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
+pixi run setup-hil
 ```
 
-Source the installation in your `.bashrc` or `.zshrc` file:
+This runs:
 
-```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-```
+| Step | pixi task       | What it does                            |
+| ---- | --------------- | --------------------------------------- |
+| 1    | `clone-ros2-ws` | `vcs import` for ROS 2 workspace        |
+| 2    | `build-ros2`    | `rosdep install` + `colcon build`       |
+| 3    | `sync`          | `uv sync` — install Python dependencies |
 
-### Setup Python Environment
+---
 
-1. Install uv
+## Setting Up llama.cpp (optional)
 
-```shell
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-2. Install dependencies
-
-```shell
-uv sync
-```
-
-## Setting Up llama.cpp
-
-llama.cpp is used as the default GenAI inference engine. Other inference engines can be used if they maintain compatibility with the OpenAI API.
+llama.cpp is used as the default local GenAI inference engine. Skip this section if using a cloud API.
 
 ### Prerequisites
 
@@ -72,25 +72,19 @@ vulkaninfo
 
 ### Build llama.cpp
 
-> [!TIP]
-> In this example, Vulkan is used as the backend. Choose the appropriate backend based on your setup. For more information, see the [llama.cpp documentation](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md).
-
 ```shell
-cd ${DEMO_ROOT}
-vcs import --input ${DEMO_ROOT}/inference.repos
+pixi run build-llama
 ```
 
-```shell
-cd ${DEMO_ROOT}/inference/llama.cpp
+This clones llama.cpp and builds it with Vulkan backend.
 
-cmake -B build -DGGML_VULKAN=1
-cmake --build build --config Release
-```
-
-### Download Model
-
-For every configured model in `config.toml`, download and run the model using the following command:
+Or, to run the full HIL setup including llama.cpp in one command:
 
 ```shell
-${DEMO_ROOT}/inference/llama.cpp/build/bin/llama-cli -hf <model/s selected in `config.toml`>
+pixi run setup-hil-local
 ```
+
+### Download Models
+
+For every model configured in `config.toml`, download the GGUF file and place it in `$DEMO_ROOT/models/`.
+See [Download Models](setup_single_machine.md#download-models) for links.

--- a/docs/setup_sim.md
+++ b/docs/setup_sim.md
@@ -13,113 +13,61 @@ This repository is compatible with the following system:
 #### Clone the Repository
 
 ```shell
-cd /home/${USER}
 git clone git@github.com:RobotecAI/agentic-mobile-manipulator.git
+cd agentic-mobile-manipulator
 ```
 
-#### Set the Root Directory of the Project
-
-Set the root directory of the project to `$DEMO_ROOT` and `$O3DE_ROOT`, e.g., by adding the following lines to your `.bashrc` or `.zshrc` file:
-
-```shell
-export DEMO_ROOT=/home/${USER}/agentic-mobile-manipulator/
-export O3DE_ROOT=${DEMO_ROOT}engine/o3de
-```
-
-#### Install Base Dependencies
+#### Install System Dependencies
 
 ```bash
 sudo apt update
-sudo apt install git git-lfs ninja-build
+sudo apt install git git-lfs python3-vcstool ninja-build \
+    cmake libstdc++-12-dev clang \
+    libglu1-mesa-dev libxcb-randr0-dev libxcb-xinerama0 libxcb-xinput0 \
+    libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev \
+    libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev \
+    mesa-common-dev libunwind-dev libzstd-dev tix
 ```
 
-#### Clone Repositories
+> [!NOTE]
+> ROS 2 Jazzy with dev tools (including `colcon`, `rosdep`) must also be installed.
+> See the [ROS 2 installation guide](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html#install-development-tools-optional).
+
+#### Install pixi
+
+[pixi](https://pixi.sh) orchestrates all build steps and sets environment variables automatically.
 
 ```shell
-cd ${DEMO_ROOT}
-vcs import --input ${DEMO_ROOT}/engine.repos
-vcs import --input ${DEMO_ROOT}/gems.repos
-vcs import --input ${DEMO_ROOT}/ros2_ws.repos
+curl -fsSL https://pixi.sh/install.sh | sh
 ```
 
-### Setup O3DE
+Restart your shell or run `source ~/.bashrc` after installation.
 
-Install [packages required to build O3DE:](https://www.docs.o3de.org/docs/welcome-guide/requirements/#linux)
+---
+
+### Build Everything
 
 ```shell
-sudo apt install cmake libstdc++-12-dev clang libglu1-mesa-dev libxcb-randr0-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev tix
+pixi run setup
 ```
 
-Register the O3DE engine:
+This single command runs the full build pipeline in the correct order:
 
-```shell
-cd ${O3DE_ROOT}
-git lfs install
-git lfs pull
-python/get_python.sh
-${O3DE_ROOT}/scripts/o3de.sh register --this-engine
-```
+| Step | pixi task       | What it does                                          |
+| ---- | --------------- | ----------------------------------------------------- |
+| 1    | `clone-engine`  | `vcs import` for O3DE engine and gems                 |
+| 2    | `clone-ros2-ws` | `vcs import` for ROS 2 workspace                      |
+| 3    | `setup-o3de`    | git-lfs pull + O3DE engine registration               |
+| 4    | `register-gems` | Register all O3DE gems and the simulation project     |
+| 5    | `build-ros2`    | `rosdep install` + `colcon build`                     |
+| 6    | `build-o3de`    | CMake configure + Ninja build (Editor + GameLauncher) |
+| 7    | `sync`          | `uv sync` — install Python dependencies               |
 
-#### Setup o3de-extras
+> [!NOTE] > `build-o3de` takes 30–60 minutes on first run.
 
-```shell
-cd ${DEMO_ROOT}/gems
-git lfs install
-git lfs pull
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path  ${DEMO_ROOT}/gems/o3de-extras/Gems
-```
+---
 
-#### Non-canonical Gems
-
-These are gems that are open source but not maintained by O3DE.
-
-```shell
-cd  ${DEMO_ROOT}/gems
-${O3DE_ROOT}/scripts/o3de.sh register --gem-path ${DEMO_ROOT}/gems/o3de-humanworker-gem
-${O3DE_ROOT}/scripts/o3de.sh register --gem-path ${DEMO_ROOT}/gems/o3de-ur-robots-gem
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path ${DEMO_ROOT}/gems/robotec-warehouse-assets
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path ${DEMO_ROOT}/gems/robotec-generic-assets
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path ${DEMO_ROOT}/gems/robotec-o3de-tools
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path ${DEMO_ROOT}/project_gems/
-
-```
-
-#### Register Project
-
-```shell
-${O3DE_ROOT}/scripts/o3de.sh register  --project-path ${DEMO_ROOT}/sim
-```
-
-### Setup ROS 2
-
-#### Build the ROS 2 Workspace
-
-```shell
-cd ${DEMO_ROOT}/ros2_ws
-rosdep update
-rosdep install --ignore-src --from-paths src -y
-colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select simulation_interfaces
-```
-
-Source the installation in your `.bashrc` or `.zshrc` file:
-
-```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-```
-
-### Build O3DE Editor and GameLauncher
-
-```shell
-cd ${DEMO_ROOT}/sim
-cmake -B build/linux -G "Ninja Multi-Config" \
-    -DLY_DISABLE_TEST_MODULES=ON \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DLY_STRIP_DEBUG_SYMBOLS=ON \
-    -DCMAKE_LINKER_TYPE=MOLD
-cmake --build build/linux --config profile --target MobileManipulatorDemo Editor MobileManipulatorDemo.Assets MobileManipulatorDemo.GameLauncher
-```
-
-### Export project to binary file
+### Export Project to Binary
 
 ```shell
 sudo apt install python3-resolvelib python3-puremagic

--- a/docs/setup_single_machine.md
+++ b/docs/setup_single_machine.md
@@ -65,8 +65,6 @@ This single command runs the full build pipeline in the correct order:
 | 5    | `build-o3de`    | CMake configure + Ninja build (Editor + GameLauncher) |
 | 6    | `sync`          | `uv sync` — install Python dependencies               |
 
-> [!NOTE] > `build-o3de` takes 30–60 minutes on first run.
-
 #### Local Inference (optional)
 
 If you want to run models locally via llama.cpp instead of cloud APIs:
@@ -74,18 +72,16 @@ If you want to run models locally via llama.cpp instead of cloud APIs:
 ```shell
 pixi run clone-inference
 pixi run build-llama
+pixi run download-models  # or download the models manually, check the links below
 ```
-
-Then [download the required models](#download-models).
 
 ---
 
 ### Running the Demo
 
-`pixi run` replaces all manual `source` calls — the ROS 2 environment is sourced automatically.
-
 ```shell
 # In separate terminals:
+pixi run serve-all    # All inference servers
 pixi run sim          # O3DE simulation
 pixi run ros2         # Full ROS 2 stack
 pixi run orchestrator # Agent orchestrator
@@ -97,28 +93,8 @@ For the HMI:
 pixi run hmi
 ```
 
-Individual agents (for debugging):
-
-```shell
-pixi run nav2-agent
-pixi run moveit2-agent
-pixi run scene-agent
-pixi run inspection-agent
-pixi run safety-agent
-```
-
-Local inference servers:
-
-```shell
-# Models default to $DEMO_ROOT/models/<filename>.
-# Override with env vars, e.g.: LLM_MODEL=/path/to/model.gguf pixi run serve-llm
-pixi run serve-llm        # GPT-OSS-20B  → port 8080
-pixi run serve-vlm        # LFM2-VL-3B   → port 8081
-pixi run serve-embedding  # Qwen3-Embedding-0.6b → port 8082
-pixi run serve-reranker   # Qwen3-Reranker-0.6B  → port 8083
-```
-
-Run `pixi task list` to see all available commands.
+> [!TIP]
+> Want to run certain part of the stack? Run `pixi task list` to see all available commands.
 
 ---
 

--- a/docs/setup_single_machine.md
+++ b/docs/setup_single_machine.md
@@ -15,150 +15,123 @@ This repository is compatible with the following system:
 ```shell
 cd /home/${USER}
 git clone git@github.com:RobotecAI/agentic-mobile-manipulator.git
+cd agentic-mobile-manipulator
 ```
 
-#### Set the Root Directory of the Project
+#### Install System Dependencies
 
-Set the root directory of the project to `$DEMO_ROOT` and `$O3DE_ROOT`, e.g., by adding the following lines to your `.bashrc` or `.zshrc` file:
-
-```shell
-export DEMO_ROOT=/home/${USER}/agentic-mobile-manipulator
-export O3DE_ROOT=${DEMO_ROOT}/engine/o3de
-```
-
-#### Install Base Dependencies
+These packages must be installed via `apt` before using pixi:
 
 ```bash
 sudo apt update
-sudo apt install git git-lfs ninja-build
+sudo apt install git git-lfs python3-vcstool ninja-build \
+    cmake libstdc++-12-dev clang \
+    libglu1-mesa-dev libxcb-randr0-dev libxcb-xinerama0 libxcb-xinput0 \
+    libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev \
+    libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev \
+    mesa-common-dev libunwind-dev libzstd-dev tix
 ```
 
-#### Clone Repositories
+> [!NOTE]
+> ROS 2 Jazzy with dev tools (including `colcon`, `rosdep`) must also be installed.
+> See the [ROS 2 installation guide](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html#install-development-tools-optional).
+
+#### Install pixi
+
+[pixi](https://pixi.sh) orchestrates all build steps and sets environment variables automatically.
 
 ```shell
-cd ${DEMO_ROOT}
-vcs import --input ${DEMO_ROOT}/engine.repos
-vcs import --input ${DEMO_ROOT}/gems.repos
-vcs import --input ${DEMO_ROOT}/ros2_ws.repos
+curl -fsSL https://pixi.sh/install.sh | sh
 ```
 
-### Setup O3DE
+Restart your shell or run `source ~/.bashrc` after installation.
 
-Install [packages required to build O3DE:](https://www.docs.o3de.org/docs/welcome-guide/requirements/#linux)
+---
+
+### Build Everything
 
 ```shell
-sudo apt install cmake libstdc++-12-dev clang libglu1-mesa-dev libxcb-randr0-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev tix
+pixi run setup
 ```
 
-Register the O3DE engine:
+This single command runs the full build pipeline in the correct order:
+
+| Step | pixi task       | What it does                                          |
+| ---- | --------------- | ----------------------------------------------------- |
+| 1    | `clone`         | `vcs import` for engine, gems, and ROS 2 workspace    |
+| 2    | `setup-o3de`    | git-lfs pull + O3DE engine registration               |
+| 3    | `register-gems` | Register all O3DE gems and the simulation project     |
+| 4    | `build-ros2`    | `rosdep install` + `colcon build`                     |
+| 5    | `build-o3de`    | CMake configure + Ninja build (Editor + GameLauncher) |
+| 6    | `sync`          | `uv sync` — install Python dependencies               |
+
+> [!NOTE] > `build-o3de` takes 30–60 minutes on first run.
+
+#### Local Inference (optional)
+
+If you want to run models locally via llama.cpp instead of cloud APIs:
 
 ```shell
-cd ${O3DE_ROOT}
-git lfs install
-git lfs pull
-python/get_python.sh
-${O3DE_ROOT}/scripts/o3de.sh register --this-engine
+pixi run clone-inference
+pixi run build-llama
 ```
 
-#### Setup o3de-extras
+Then [download the required models](#download-models).
+
+---
+
+### Running the Demo
+
+`pixi run` replaces all manual `source` calls — the ROS 2 environment is sourced automatically.
 
 ```shell
-cd ${DEMO_ROOT}/gems
-git lfs install
-git lfs pull
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path  ${DEMO_ROOT}/gems/o3de-extras/Gems
+# In separate terminals:
+pixi run sim          # O3DE simulation
+pixi run ros2         # Full ROS 2 stack
+pixi run orchestrator # Agent orchestrator
 ```
 
-#### Non-canonical Gems
-
-These are gems that are open source but not maintained by O3DE.
+For the HMI:
 
 ```shell
-cd  ${DEMO_ROOT}/gems
-${O3DE_ROOT}/scripts/o3de.sh register --gem-path ${DEMO_ROOT}/gems/o3de-humanworker-gem
-${O3DE_ROOT}/scripts/o3de.sh register --gem-path ${DEMO_ROOT}/gems/o3de-ur-robots-gem
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path ${DEMO_ROOT}/gems/robotec-warehouse-assets
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path ${DEMO_ROOT}/gems/robotec-generic-assets
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path ${DEMO_ROOT}/gems/robotec-o3de-tools
-${O3DE_ROOT}/scripts/o3de.sh register --all-gems-path ${DEMO_ROOT}/project_gems/
+pixi run hmi
 ```
 
-#### Register Project
+Individual agents (for debugging):
 
 ```shell
-${O3DE_ROOT}/scripts/o3de.sh register  --project-path ${DEMO_ROOT}/sim
+pixi run nav2-agent
+pixi run moveit2-agent
+pixi run scene-agent
+pixi run inspection-agent
+pixi run safety-agent
 ```
 
-### Setup ROS 2
-
-#### Build the ROS 2 Workspace
+Local inference servers:
 
 ```shell
-cd ${DEMO_ROOT}/ros2_ws
-rosdep update
-rosdep install --ignore-src --from-paths src -y
-colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
+# Models default to $DEMO_ROOT/models/<filename>.
+# Override with env vars, e.g.: LLM_MODEL=/path/to/model.gguf pixi run serve-llm
+pixi run serve-llm        # GPT-OSS-20B  → port 8080
+pixi run serve-vlm        # LFM2-VL-3B   → port 8081
+pixi run serve-embedding  # Qwen3-Embedding-0.6b → port 8082
+pixi run serve-reranker   # Qwen3-Reranker-0.6B  → port 8083
 ```
 
-Source the installation in your `.bashrc` or `.zshrc` file:
+Run `pixi task list` to see all available commands.
 
-```shell
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-```
-
-### Build O3DE Editor and GameLauncher
-
-```shell
-cd ${DEMO_ROOT}/sim
-cmake -B build/linux -G "Ninja Multi-Config" \
-    -DLY_DISABLE_TEST_MODULES=ON \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DLY_STRIP_DEBUG_SYMBOLS=ON \
-    -DCMAKE_LINKER_TYPE=MOLD
-cmake --build build/linux --config profile --target MobileManipulatorDemo Editor MobileManipulatorDemo.Assets MobileManipulatorDemo.GameLauncher
-```
-
-### Setup Python Environment
-
-1. Install uv
-
-```shell
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-2. Install dependencies
-
-```shell
-uv sync
-```
-
-### Setting Up llama.cpp (local inference)
-
-> [!TIP]
-> For the demo presented at ROSCon 2025, the Vulkan backend was used. For more information, see the [llama.cpp documentation](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md).
-
-```shell
-cd ${DEMO_ROOT}
-vcs import --input ${DEMO_ROOT}/inference.repos
-```
-
-```shell
-cd ${DEMO_ROOT}/inference/llama.cpp
-
-cmake -B build -DGGML_VULKAN=1
-cmake --build build --config Release
-```
+---
 
 ### Download Models
 
-For every configured model in `config.toml`, download the appropriate GGUF file and run it via `llama-server`.
-
-For the default setup, download the following models:
+For every model configured in `config.toml`, download the GGUF file and place it in `$DEMO_ROOT/models/`:
 
 - [GPT-OSS-20B](https://huggingface.co/unsloth/gpt-oss-20b-GGUF/resolve/main/gpt-oss-20b-Q4_K_M.gguf?download=true)
-- [LFM2-VL-3B-GGUF](https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/LFM2-VL-3B-Q8_0.gguf?download=true) along with [mmproj](https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/mmproj-LFM2-VL-3B-Q8_0.gguf?download=true)
+- [LFM2-VL-3B-GGUF](https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/LFM2-VL-3B-Q8_0.gguf?download=true) + [mmproj](https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/mmproj-LFM2-VL-3B-Q8_0.gguf?download=true)
 - [Qwen3-Embedding-0.6b](https://robotecai-my.sharepoint.com/:u:/g/personal/bartlomiej_boczek_robotec_ai/IQB7tkMkmi34Q6xtTB89N1LxAfod0sMpGT4uTffjo6iW7qc?e=6kLoTi)
 - [Qwen3-Reranker-0.6B](https://robotecai-my.sharepoint.com/:u:/g/personal/bartlomiej_boczek_robotec_ai/IQAgWOVPiyS8RZ1QUVVx6N9gAaOGGrvDnk7Qa0IpSbhlp_8?e=P0b1Ak)
+
+---
 
 ## Developer Setup
 
@@ -168,11 +141,14 @@ We use conventional commits to ensure that the commit messages are consistent an
 
 ### Pre-commit
 
-We use pre-commit to ensure that the code is formatted and linted before it is committed.
+```bash
+pixi run pre-commit-install
+```
+
+To run hooks manually:
 
 ```bash
-sudo apt install pre-commit
-pre-commit install
+pixi run lint
 ```
 
 # Next Steps

--- a/docs/setup_single_machine.md
+++ b/docs/setup_single_machine.md
@@ -71,7 +71,7 @@ If you want to run models locally via llama.cpp instead of cloud APIs:
 
 ```shell
 pixi run clone-inference
-pixi run build-llama
+pixi run build-llama # this step is hardware specifc. By default, it builds with Vulkan backend. Check for better solutions for your hardware.
 pixi run download-models  # or download the models manually, check the links below
 ```
 

--- a/docs/setup_single_machine.md
+++ b/docs/setup_single_machine.md
@@ -77,27 +77,6 @@ pixi run download-models  # or download the models manually, check the links bel
 
 ---
 
-### Running the Demo
-
-```shell
-# In separate terminals:
-pixi run serve-all    # All inference servers
-pixi run sim          # O3DE simulation
-pixi run ros2         # Full ROS 2 stack
-pixi run orchestrator # Agent orchestrator
-```
-
-For the HMI:
-
-```shell
-pixi run hmi
-```
-
-> [!TIP]
-> Want to run certain part of the stack? Run `pixi task list` to see all available commands.
-
----
-
 ### Download Models
 
 For every model configured in `config.toml`, download the GGUF file and place it in `$DEMO_ROOT/models/`:

--- a/docs/setup_single_machine.md
+++ b/docs/setup_single_machine.md
@@ -128,8 +128,8 @@ For every model configured in `config.toml`, download the GGUF file and place it
 
 - [GPT-OSS-20B](https://huggingface.co/unsloth/gpt-oss-20b-GGUF/resolve/main/gpt-oss-20b-Q4_K_M.gguf?download=true)
 - [LFM2-VL-3B-GGUF](https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/LFM2-VL-3B-Q8_0.gguf?download=true) + [mmproj](https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/mmproj-LFM2-VL-3B-Q8_0.gguf?download=true)
-- [Qwen3-Embedding-0.6b](https://robotecai-my.sharepoint.com/:u:/g/personal/bartlomiej_boczek_robotec_ai/IQB7tkMkmi34Q6xtTB89N1LxAfod0sMpGT4uTffjo6iW7qc?e=6kLoTi)
-- [Qwen3-Reranker-0.6B](https://robotecai-my.sharepoint.com/:u:/g/personal/bartlomiej_boczek_robotec_ai/IQAgWOVPiyS8RZ1QUVVx6N9gAaOGGrvDnk7Qa0IpSbhlp_8?e=P0b1Ak)
+- [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf?download=true)
+- [Qwen3-Reranker-0.6B](https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/main/qwen3-reranker-0.6b-q8_0.gguf?download=true)
 
 ---
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,74 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.7-h0f56927_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+  sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
+  md5: 0aa00f03f9e39fb9876085dee11a85d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_18
+  - libgomp 15.2.0 he0feb66_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1041788
+  timestamp: 1771378212382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+  sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
+  md5: 239c5e9546c38a1e884d69effcf4c882
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 603262
+  timestamp: 1771378117851
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+  sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
+  md5: 1b08cd684f34175e4514474793d44bcb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_18
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 5852330
+  timestamp: 1771378262446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.7-h0f56927_0.conda
+  sha256: 46b01d5a26aa9d0b304b3bd96e5882083254e7688c43687fef2d066bc97c02c5
+  md5: c1c843d3c59957d6ab6161a93d89086d
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR MIT
+  size: 19287808
+  timestamp: 1776299150878

--- a/pixi.toml
+++ b/pixi.toml
@@ -161,37 +161,43 @@ cmd = "$DEMO_ROOT/scripts/start_safety_agent.sh"
 description = "Launch safety agent (with RAG)"
 
 # ─── Local Inference ────────────────────────────────────────────────────────────
-# Set the model env vars before running, e.g.:
+# Default model paths assume models are placed in $DEMO_ROOT/models/.
+# Override by setting the env var before running, e.g.:
 #   LLM_MODEL=/path/to/gpt-oss-20b-Q4_K_M.gguf pixi run serve-llm
-#
-# Default paths assume models are placed in $DEMO_ROOT/models/.
+
+[tasks.download-models]
+cmd = "bash $DEMO_ROOT/scripts/download_models.sh"
+description = "Download models for local inference (embedding/reranker must be downloaded manually)"
+
+[tasks.serve-all]
+cmd = "bash $DEMO_ROOT/scripts/serve_all.sh"
+description = "Launch all inference servers in a tmux session (2x2 grid)"
 
 [tasks.serve-llm]
-cmd = """$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server \
-    -m ${LLM_MODEL:-$DEMO_ROOT/models/gpt-oss-20b-Q4_K_M.gguf} \
-    --no-prefill-assistant --port 8080"""
+cmd = "$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server -m $LLM_MODEL --no-prefill-assistant --port 8080"
+env = { LLM_MODEL = "$DEMO_ROOT/models/gpt-oss-20b-Q4_K_M.gguf" }
 description = "Serve GPT-OSS-20B on port 8080 (set LLM_MODEL to override path)"
 
 [tasks.serve-vlm]
-cmd = """$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server \
-    -m ${VLM_MODEL:-$DEMO_ROOT/models/LFM2-VL-3B-Q8_0.gguf} \
-    --mmproj ${VLM_MMPROJ:-$DEMO_ROOT/models/mmproj-LFM2-VL-3B-Q8_0.gguf} \
-    --port 8081"""
+cmd = "$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server -m $VLM_MODEL --mmproj $VLM_MMPROJ --port 8081"
+env = { VLM_MODEL = "$DEMO_ROOT/models/LFM2-VL-3B-Q8_0.gguf", VLM_MMPROJ = "$DEMO_ROOT/models/mmproj-LFM2-VL-3B-Q8_0.gguf" }
 description = "Serve LFM2-VL-3B on port 8081 (set VLM_MODEL / VLM_MMPROJ to override paths)"
 
 [tasks.serve-embedding]
-cmd = """$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server \
-    -m ${EMBEDDING_MODEL:-$DEMO_ROOT/models/Qwen3-Embedding-0.6b_Q8_0.gguf} \
-    --embedding --pooling last -c 4096 -b 2048 -ub 2048 --port 8082"""
+cmd = "$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server -m $EMBEDDING_MODEL --embedding --pooling last -c 4096 -b 2048 -ub 2048 --port 8082"
+env = { EMBEDDING_MODEL = "$DEMO_ROOT/models/Qwen3-Embedding-0.6b_Q8_0.gguf" }
 description = "Serve Qwen3-Embedding-0.6b on port 8082"
 
 [tasks.serve-reranker]
-cmd = """$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server \
-    -m ${RERANKER_MODEL:-$DEMO_ROOT/models/Qwen3-Reranker-0.6B.gguf} \
-    --embedding --pooling rank -c 4096 -b 2048 -ub 2048 --port 8083"""
+cmd = "$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server -m $RERANKER_MODEL --embedding --pooling rank -c 4096 -b 2048 -ub 2048 --port 8083"
+env = { RERANKER_MODEL = "$DEMO_ROOT/models/Qwen3-Reranker-0.6B.gguf" }
 description = "Serve Qwen3-Reranker-0.6B on port 8083"
 
 # ─── Dev Tasks ──────────────────────────────────────────────────────────────────
+
+[tasks.smoke-test]
+cmd = "bash $DEMO_ROOT/scripts/smoke_test.sh"
+description = "Check if all LLM inference servers are up"
 
 [tasks.pre-commit-install]
 cmd = "uv run pre-commit install"

--- a/pixi.toml
+++ b/pixi.toml
@@ -170,9 +170,7 @@ cmd = "bash $DEMO_ROOT/scripts/demo.sh"
 description = "Start full demo: sim → ros2 → inference → orchestrator (3 tmux sessions)"
 
 [tasks.demo-stop]
-cmd = """for s in simulation inference agent; do
-    tmux kill-session -t "$s" 2>/dev/null && echo "  killed '$s'" || true
-done"""
+cmd = "bash $DEMO_ROOT/scripts/demo_stop.sh"
 description = "Stop all demo tmux sessions"
 
 [tasks.download-models]

--- a/pixi.toml
+++ b/pixi.toml
@@ -165,6 +165,16 @@ description = "Launch safety agent (with RAG)"
 # Override by setting the env var before running, e.g.:
 #   LLM_MODEL=/path/to/gpt-oss-20b-Q4_K_M.gguf pixi run serve-llm
 
+[tasks.demo]
+cmd = "bash $DEMO_ROOT/scripts/demo.sh"
+description = "Start full demo: sim → ros2 → inference → orchestrator (3 tmux sessions)"
+
+[tasks.demo-stop]
+cmd = """for s in simulation inference agent; do
+    tmux kill-session -t "$s" 2>/dev/null && echo "  killed '$s'" || true
+done"""
+description = "Stop all demo tmux sessions"
+
 [tasks.download-models]
 cmd = "bash $DEMO_ROOT/scripts/download_models.sh"
 description = "Download models for local inference"

--- a/pixi.toml
+++ b/pixi.toml
@@ -167,7 +167,7 @@ description = "Launch safety agent (with RAG)"
 
 [tasks.download-models]
 cmd = "bash $DEMO_ROOT/scripts/download_models.sh"
-description = "Download models for local inference (embedding/reranker must be downloaded manually)"
+description = "Download models for local inference"
 
 [tasks.serve-all]
 cmd = "bash $DEMO_ROOT/scripts/serve_all.sh"
@@ -185,12 +185,12 @@ description = "Serve LFM2-VL-3B on port 8081 (set VLM_MODEL / VLM_MMPROJ to over
 
 [tasks.serve-embedding]
 cmd = "$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server -m $EMBEDDING_MODEL --embedding --pooling last -c 4096 -b 2048 -ub 2048 --port 8082"
-env = { EMBEDDING_MODEL = "$DEMO_ROOT/models/Qwen3-Embedding-0.6b_Q8_0.gguf" }
+env = { EMBEDDING_MODEL = "$DEMO_ROOT/models/Qwen3-Embedding-0.6B-Q8_0.gguf" }
 description = "Serve Qwen3-Embedding-0.6b on port 8082"
 
 [tasks.serve-reranker]
 cmd = "$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server -m $RERANKER_MODEL --embedding --pooling rank -c 4096 -b 2048 -ub 2048 --port 8083"
-env = { RERANKER_MODEL = "$DEMO_ROOT/models/Qwen3-Reranker-0.6B_16BF.gguf" }
+env = { RERANKER_MODEL = "$DEMO_ROOT/models/qwen3-reranker-0.6b-q8_0.gguf" }
 description = "Serve Qwen3-Reranker-0.6B on port 8083"
 
 # ─── Dev Tasks ──────────────────────────────────────────────────────────────────

--- a/pixi.toml
+++ b/pixi.toml
@@ -190,7 +190,7 @@ description = "Serve Qwen3-Embedding-0.6b on port 8082"
 
 [tasks.serve-reranker]
 cmd = "$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server -m $RERANKER_MODEL --embedding --pooling rank -c 4096 -b 2048 -ub 2048 --port 8083"
-env = { RERANKER_MODEL = "$DEMO_ROOT/models/Qwen3-Reranker-0.6B.gguf" }
+env = { RERANKER_MODEL = "$DEMO_ROOT/models/Qwen3-Reranker-0.6B_16BF.gguf" }
 description = "Serve Qwen3-Reranker-0.6B on port 8083"
 
 # ─── Dev Tasks ──────────────────────────────────────────────────────────────────

--- a/pixi.toml
+++ b/pixi.toml
@@ -93,7 +93,7 @@ description = "Build O3DE Editor and GameLauncher (slow — takes 30–60 min)"
 cmd = """
 cd $DEMO_ROOT/inference/llama.cpp &&
 cmake -B build -DGGML_VULKAN=1 &&
-cmake --build build --config Release
+cmake --build build --config Release -j $(nproc)
 """
 depends-on = ["clone-inference"]
 description = "Clone and build llama.cpp with Vulkan backend (standalone, no O3DE/ROS 2 required)"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,206 @@
+[workspace]
+name = "agentic-mobile-manipulator"
+version = "1.0.0"
+description = "Agentic Mobile Manipulator Demo"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+# ─── Environment ────────────────────────────────────────────────────────────────
+# DEMO_ROOT and O3DE_ROOT are set automatically — no need to add them to .bashrc.
+# pixi_activate.sh sources ROS 2 setup files when available.
+[activation]
+env = { DEMO_ROOT = "${PIXI_PROJECT_ROOT}", O3DE_ROOT = "${PIXI_PROJECT_ROOT}/engine/o3de" }
+scripts = ["pixi_activate.sh"]
+
+[dependencies]
+# uv is the Python package manager used by this project.
+# All other build tools (cmake, ninja, clang, colcon, vcs) come from the ROS 2
+# dev-tools apt installation documented in docs/setup_single_machine.md.
+uv = ">=0.5"
+
+# ─── Setup Tasks ────────────────────────────────────────────────────────────────
+
+[tasks.clone-engine]
+cmd = """
+vcs import --input $DEMO_ROOT/engine.repos &&
+vcs import --input $DEMO_ROOT/gems.repos
+"""
+description = "Clone O3DE engine and gems"
+
+[tasks.clone-ros2-ws]
+cmd = "vcs import --input $DEMO_ROOT/ros2_ws.repos"
+description = "Clone ROS 2 workspace repositories"
+
+[tasks.clone]
+depends-on = ["clone-engine", "clone-ros2-ws"]
+description = "Clone all repositories (engine, gems, and ROS 2 workspace)"
+
+[tasks.clone-inference]
+cmd = "vcs import --input $DEMO_ROOT/inference.repos"
+description = "Clone llama.cpp (required for local inference)"
+
+[tasks.setup-o3de]
+cmd = """
+cd $O3DE_ROOT &&
+git lfs install && git lfs pull &&
+python/get_python.sh &&
+$O3DE_ROOT/scripts/o3de.sh register --this-engine
+"""
+depends-on = ["clone-engine"]
+description = "Pull O3DE LFS assets and register the engine"
+
+[tasks.register-gems]
+cmd = """
+cd $DEMO_ROOT/gems && git lfs install && git lfs pull &&
+$O3DE_ROOT/scripts/o3de.sh register --all-gems-path $DEMO_ROOT/gems/o3de-extras/Gems &&
+$O3DE_ROOT/scripts/o3de.sh register --gem-path $DEMO_ROOT/gems/o3de-humanworker-gem &&
+$O3DE_ROOT/scripts/o3de.sh register --gem-path $DEMO_ROOT/gems/o3de-ur-robots-gem &&
+$O3DE_ROOT/scripts/o3de.sh register --all-gems-path $DEMO_ROOT/gems/robotec-warehouse-assets &&
+$O3DE_ROOT/scripts/o3de.sh register --all-gems-path $DEMO_ROOT/gems/robotec-generic-assets &&
+$O3DE_ROOT/scripts/o3de.sh register --all-gems-path $DEMO_ROOT/gems/robotec-o3de-tools &&
+$O3DE_ROOT/scripts/o3de.sh register --all-gems-path $DEMO_ROOT/project_gems/ &&
+$O3DE_ROOT/scripts/o3de.sh register --project-path $DEMO_ROOT/sim --force
+"""
+depends-on = ["setup-o3de"]
+description = "Register all O3DE gems and the simulation project"
+
+[tasks.build-ros2]
+cmd = """
+cd $DEMO_ROOT/ros2_ws &&
+rosdep update &&
+rosdep install --ignore-src --from-paths src -y &&
+colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
+"""
+depends-on = ["clone-ros2-ws"]
+description = "Build the ROS 2 workspace with colcon"
+
+[tasks.build-o3de]
+cmd = """
+cd $DEMO_ROOT/sim &&
+cmake -B build/linux -G "Ninja Multi-Config" \
+    -DCMAKE_MODULE_PATH=$O3DE_ROOT/cmake \
+    -DLY_DISABLE_TEST_MODULES=ON \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DLY_STRIP_DEBUG_SYMBOLS=ON \
+    -DCMAKE_LINKER_TYPE=MOLD &&
+cmake --build build/linux --config profile \
+    --target MobileManipulatorDemo Editor MobileManipulatorDemo.Assets MobileManipulatorDemo.GameLauncher
+"""
+depends-on = ["register-gems", "build-ros2"]
+description = "Build O3DE Editor and GameLauncher (slow — takes 30–60 min)"
+
+[tasks.build-llama]
+cmd = """
+cd $DEMO_ROOT/inference/llama.cpp &&
+cmake -B build -DGGML_VULKAN=1 &&
+cmake --build build --config Release
+"""
+depends-on = ["clone-inference"]
+description = "Clone and build llama.cpp with Vulkan backend (standalone, no O3DE/ROS 2 required)"
+
+[tasks.sync]
+cmd = "uv sync"
+description = "Install Python dependencies"
+
+# Full setup: runs all build steps in dependency order.
+# Run pixi run setup-local if you also need local llama.cpp inference.
+[tasks.setup]
+depends-on = ["build-ros2", "build-o3de", "sync"]
+description = "Full setup (O3DE + ROS 2 + Python). See also: setup-local."
+
+[tasks.setup-hil]
+depends-on = ["build-ros2", "sync"]
+description = "Setup HIL machine (ROS 2 workspace + Python, no O3DE)"
+
+[tasks.setup-hil-local]
+depends-on = ["setup-hil", "build-llama"]
+description = "Setup HIL machine including local llama.cpp inference"
+
+[tasks.setup-local]
+depends-on = ["setup", "build-llama"]
+description = "Full setup including local llama.cpp inference"
+
+# ─── Run Tasks ──────────────────────────────────────────────────────────────────
+# These tasks assume the workspace has been sourced via pixi_activate.sh.
+
+[tasks.sim]
+cmd = "$DEMO_ROOT/sim/build/linux/bin/profile/MobileManipulatorDemo.GameLauncher -bg_ConnectToAssetProcessor=0"
+description = "Launch O3DE simulation"
+
+[tasks.ros2]
+cmd = "$DEMO_ROOT/scripts/run_ros2_stack.sh"
+description = "Launch full ROS 2 stack (robot, nav2, moveit2, scene, agents)"
+
+[tasks.hmi]
+cmd = "ros2 launch mobile_manipulator_hmi hmi_launch.py"
+description = "Launch the Human-Machine Interface"
+
+[tasks.orchestrator]
+cmd = "uv run python rai_app/agents/agent_orchestrator.py"
+description = "Launch the agent orchestrator"
+
+# Individual agents — use these instead of ros2 when debugging a specific component.
+[tasks.nav2-agent]
+cmd = "uv run python rai_app/agents/nav2_agent.py"
+description = "Launch nav2 agent"
+
+[tasks.moveit2-agent]
+cmd = "uv run python rai_app/agents/moveit2_agent.py"
+description = "Launch moveit2 agent"
+
+[tasks.scene-agent]
+cmd = "uv run python rai_app/environment/scene_agent.py"
+description = "Launch scene agent"
+
+[tasks.inspection-agent]
+cmd = "uv run python rai_app/agents/inspection_agent.py"
+description = "Launch inspection agent"
+
+[tasks.safety-agent]
+cmd = "$DEMO_ROOT/scripts/start_safety_agent.sh"
+description = "Launch safety agent (with RAG)"
+
+# ─── Local Inference ────────────────────────────────────────────────────────────
+# Set the model env vars before running, e.g.:
+#   LLM_MODEL=/path/to/gpt-oss-20b-Q4_K_M.gguf pixi run serve-llm
+#
+# Default paths assume models are placed in $DEMO_ROOT/models/.
+
+[tasks.serve-llm]
+cmd = """$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server \
+    -m ${LLM_MODEL:-$DEMO_ROOT/models/gpt-oss-20b-Q4_K_M.gguf} \
+    --no-prefill-assistant --port 8080"""
+description = "Serve GPT-OSS-20B on port 8080 (set LLM_MODEL to override path)"
+
+[tasks.serve-vlm]
+cmd = """$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server \
+    -m ${VLM_MODEL:-$DEMO_ROOT/models/LFM2-VL-3B-Q8_0.gguf} \
+    --mmproj ${VLM_MMPROJ:-$DEMO_ROOT/models/mmproj-LFM2-VL-3B-Q8_0.gguf} \
+    --port 8081"""
+description = "Serve LFM2-VL-3B on port 8081 (set VLM_MODEL / VLM_MMPROJ to override paths)"
+
+[tasks.serve-embedding]
+cmd = """$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server \
+    -m ${EMBEDDING_MODEL:-$DEMO_ROOT/models/Qwen3-Embedding-0.6b_Q8_0.gguf} \
+    --embedding --pooling last -c 4096 -b 2048 -ub 2048 --port 8082"""
+description = "Serve Qwen3-Embedding-0.6b on port 8082"
+
+[tasks.serve-reranker]
+cmd = """$DEMO_ROOT/inference/llama.cpp/build/bin/llama-server \
+    -m ${RERANKER_MODEL:-$DEMO_ROOT/models/Qwen3-Reranker-0.6B.gguf} \
+    --embedding --pooling rank -c 4096 -b 2048 -ub 2048 --port 8083"""
+description = "Serve Qwen3-Reranker-0.6B on port 8083"
+
+# ─── Dev Tasks ──────────────────────────────────────────────────────────────────
+
+[tasks.pre-commit-install]
+cmd = "uv run pre-commit install"
+description = "Install pre-commit hooks"
+
+[tasks.lint]
+cmd = "uv run pre-commit run --all-files"
+description = "Run all linters and formatters"
+
+[tasks.test]
+cmd = "uv run pytest"
+description = "Run test suite"

--- a/pixi_activate.sh
+++ b/pixi_activate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Sourced by pixi on environment activation.
+# Sets up ROS 2 Jazzy paths so that pixi shell / pixi run tasks have a full
+# ROS 2 environment without needing manual `source` calls.
+
+# Base ROS 2 installation
+if [ -f "/opt/ros/jazzy/setup.bash" ]; then
+    # shellcheck source=/dev/null
+    source "/opt/ros/jazzy/setup.bash"
+fi
+
+# Project ROS 2 workspace (available after `pixi run build-ros2`)
+if [ -f "${DEMO_ROOT}/ros2_ws/install/setup.bash" ]; then
+    # shellcheck source=/dev/null
+    source "${DEMO_ROOT}/ros2_ws/install/setup.bash"
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ include = ["scripts*", "rai_app*"]
 requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.uv.workspace]
+exclude = ["inference/*"]
+
 [tool.pytest.ini_options]
 addopts = "-vv"
 testpaths = ["tests"]

--- a/rai_app/README.md
+++ b/rai_app/README.md
@@ -157,22 +157,26 @@ tasks queue topic-> /orchestrator/tasks_queue, std_msgs/msg/String
 
 ## Setup and Run
 
-1. Follow the basic setup instructions [here](../docs/setup.md).
+1. Follow the setup instructions [here](../docs/setup_single_machine.md).
 2. Setup your vendor and model in config [here](../config.toml). If using default openai, remember to set OPENAI_API_KEY env.
-3. Launch the simulation.
-4. launch the robotic stack
+3. Launch the simulation:
 
 ```bash
-./scripts/run_ros2_stack.sh
+pixi run sim
 ```
 
-5. Spawn objects in HMI, chosing from different scenarios
+4. Launch the robotic stack:
+
+```bash
+pixi run ros2
+```
+
+5. Spawn objects in HMI, choosing from different scenarios
 
 6. Run orchestrator:
 
 ```bash
-source ${DEMO_ROOT}/ros2_ws/install/setup.bash
-uv run rai_app/agents/agent_orchestrator.py
+pixi run orchestrator
 ```
 
 7. Send tasks via HMI

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+log()    { echo -e "  ${GREEN}●${RESET} $*"; }
+warn()   { echo -e "  ${YELLOW}!${RESET} $*"; }
+err()    { echo -e "  ${RED}✗${RESET} $*" >&2; exit 1; }
+ok()     { echo -e "  ${GREEN}✓${RESET} $*"; }
+section(){ echo -e "\n${BOLD}${CYAN}$*${RESET}"; }
+
+# ── Guard ─────────────────────────────────────────────────────────────────────
+
+for s in simulation inference agent; do
+    if tmux has-session -t "$s" 2>/dev/null; then
+        warn "Session '$s' already exists."
+        warn "Run 'pixi run demo-stop' first, or attach with: tmux attach -t $s"
+        exit 1
+    fi
+done
+
+trap 'echo; warn "Interrupted. Run: pixi run demo-stop"' INT TERM
+
+# ── 1. Simulation ─────────────────────────────────────────────────────────────
+
+section "Starting simulation..."
+
+tmux new-session -d -s simulation -x 220 -y 50
+tmux rename-window -t simulation:0 "sim+ros2"
+tmux split-window -v -t simulation:0.0
+
+tmux send-keys -t simulation:0.0 "cd $DEMO_ROOT && pixi run sim" Enter
+log "O3DE launched  (simulation — top pane)"
+
+echo -ne "  ${YELLOW}○${RESET} Waiting for /clock"
+elapsed=0
+while ! ros2 topic list 2>/dev/null | grep -q "^/clock$"; do
+    sleep 2; elapsed=$((elapsed + 2)); echo -n "."
+    [ $elapsed -ge 120 ] && echo && err "Timed out waiting for /clock (120 s)"
+done
+echo -e " ${GREEN}✓${RESET}"
+
+# ── 2. ROS 2 Stack ────────────────────────────────────────────────────────────
+
+section "Starting ROS 2 stack..."
+
+tmux send-keys -t simulation:0.1 "cd $DEMO_ROOT && pixi run ros2" Enter
+ok "ROS 2 stack launched  (simulation — bottom pane)"
+
+# ── 3. Inference servers ──────────────────────────────────────────────────────
+
+section "Starting inference servers..."
+
+tmux new-session -d -s inference -x 220 -y 50
+tmux rename-window -t inference:0 "models"
+tmux split-window -h -t inference:0.0
+tmux split-window -v -t inference:0.0
+tmux split-window -v -t inference:0.2
+tmux select-layout -t inference:0 tiled
+
+tmux send-keys -t inference:0.0 "cd $DEMO_ROOT && pixi run serve-llm"       Enter
+tmux send-keys -t inference:0.1 "cd $DEMO_ROOT && pixi run serve-embedding"  Enter
+tmux send-keys -t inference:0.2 "cd $DEMO_ROOT && pixi run serve-vlm"        Enter
+tmux send-keys -t inference:0.3 "cd $DEMO_ROOT && pixi run serve-reranker"   Enter
+
+log "Inference session created  (inference — 2×2 grid)"
+
+echo -ne "  ${YELLOW}○${RESET} Waiting for inference servers"
+elapsed=0
+while true; do
+    all_up=true
+    for port in 8080 8081 8082 8083; do
+        code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
+               "http://localhost:$port/health" 2>/dev/null)
+        [ "$code" != "200" ] && all_up=false && break
+    done
+    if $all_up; then echo -e " ${GREEN}✓${RESET}"; break; fi
+    sleep 5; elapsed=$((elapsed + 5)); echo -n "."
+    if [ $elapsed -ge 600 ]; then
+        echo
+        warn "Not all inference servers ready after 600 s — continuing anyway"
+        break
+    fi
+done
+
+# ── 4. Orchestrator ───────────────────────────────────────────────────────────
+
+section "Starting orchestrator..."
+
+tmux new-session -d -s agent -x 220 -y 50
+tmux rename-window -t agent:0 "orchestrator"
+tmux send-keys -t agent:0 "cd $DEMO_ROOT && pixi run orchestrator" Enter
+ok "Orchestrator launched  (agent)"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}${GREEN}=== Demo running ===${RESET}"
+echo ""
+echo -e "  ${CYAN}tmux attach -t simulation${RESET}   — O3DE sim (top) + ROS 2 stack (bottom)"
+echo -e "  ${CYAN}tmux attach -t inference${RESET}    — 4 inference servers (2×2 grid)"
+echo -e "  ${CYAN}tmux attach -t agent${RESET}        — orchestrator"
+echo ""
+echo -e "  Stop everything:  ${YELLOW}pixi run demo-stop${RESET}"
+echo ""

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -8,11 +8,45 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
-log()    { echo -e "  ${GREEN}●${RESET} $*"; }
-warn()   { echo -e "  ${YELLOW}!${RESET} $*"; }
-err()    { echo -e "  ${RED}✗${RESET} $*" >&2; exit 1; }
-ok()     { echo -e "  ${GREEN}✓${RESET} $*"; }
-section(){ echo -e "\n${BOLD}${CYAN}$*${RESET}"; }
+log()     { echo -e "  ${GREEN}●${RESET} $*"; }
+warn()    { echo -e "  ${YELLOW}!${RESET} $*"; }
+err()     { echo -e "  ${RED}✗${RESET} $*" >&2; }
+ok()      { echo -e "  ${GREEN}✓${RESET} $*"; }
+section() { echo -e "\n${BOLD}${CYAN}$*${RESET}"; }
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+wait_topic() {
+    local topic="$1" timeout="${2:-120}" elapsed=0 dots=""
+    echo -ne "  ${YELLOW}○${RESET} Waiting for ${topic}"
+    while ! ros2 topic list 2>/dev/null | grep -q "^${topic}$"; do
+        sleep 2; elapsed=$((elapsed + 2)); dots="${dots}."; echo -n "."
+        if [ $elapsed -ge $timeout ]; then
+            printf " ${RED}✗${RESET}\n"
+            err "Timed out waiting for ${topic} (${timeout}s)"
+            return 1
+        fi
+    done
+    printf "\r  ${GREEN}●${RESET} Waiting for ${topic}%s ${GREEN}✓${RESET}\n" "$dots"
+}
+
+check_inference() {
+    log "Waiting 10s for inference servers to initialize..."
+    sleep 10
+    if bash "$DEMO_ROOT/scripts/smoke_test.sh"; then
+        return 0
+    else
+        echo ""
+        warn "Inference servers not healthy. Inspect with: pixi run serve-all"
+        return 1
+    fi
+}
+
+stop_all() {
+    for s in simulation inference agent; do
+        tmux kill-session -t "$s" 2>/dev/null || true
+    done
+}
 
 # ── Guard ─────────────────────────────────────────────────────────────────────
 
@@ -24,7 +58,7 @@ for s in simulation inference agent; do
     fi
 done
 
-trap 'echo; warn "Interrupted. Run: pixi run demo-stop"' INT TERM
+trap 'echo; warn "Interrupted — cleaning up..."; stop_all; exit 1' INT TERM QUIT
 
 # ── 1. Simulation ─────────────────────────────────────────────────────────────
 
@@ -37,20 +71,16 @@ tmux split-window -v -t simulation:0.0
 tmux send-keys -t simulation:0.0 "cd $DEMO_ROOT && pixi run sim" Enter
 log "O3DE launched  (simulation — top pane)"
 
-echo -ne "  ${YELLOW}○${RESET} Waiting for /clock"
-elapsed=0
-while ! ros2 topic list 2>/dev/null | grep -q "^/clock$"; do
-    sleep 2; elapsed=$((elapsed + 2)); echo -n "."
-    [ $elapsed -ge 120 ] && echo && err "Timed out waiting for /clock (120 s)"
-done
-echo -e " ${GREEN}✓${RESET}"
+wait_topic "/clock" 120 || { stop_all; exit 1; }
 
 # ── 2. ROS 2 Stack ────────────────────────────────────────────────────────────
 
 section "Starting ROS 2 stack..."
 
 tmux send-keys -t simulation:0.1 "cd $DEMO_ROOT && pixi run ros2" Enter
-ok "ROS 2 stack launched  (simulation — bottom pane)"
+log "ROS 2 stack launched  (simulation — bottom pane)"
+
+wait_topic "/joint_states" 60 || { stop_all; exit 1; }
 
 # ── 3. Inference servers ──────────────────────────────────────────────────────
 
@@ -67,26 +97,9 @@ tmux send-keys -t inference:0.0 "cd $DEMO_ROOT && pixi run serve-llm"       Ente
 tmux send-keys -t inference:0.1 "cd $DEMO_ROOT && pixi run serve-embedding"  Enter
 tmux send-keys -t inference:0.2 "cd $DEMO_ROOT && pixi run serve-vlm"        Enter
 tmux send-keys -t inference:0.3 "cd $DEMO_ROOT && pixi run serve-reranker"   Enter
-
 log "Inference session created  (inference — 2×2 grid)"
 
-echo -ne "  ${YELLOW}○${RESET} Waiting for inference servers"
-elapsed=0
-while true; do
-    all_up=true
-    for port in 8080 8081 8082 8083; do
-        code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
-               "http://localhost:$port/health" 2>/dev/null)
-        [ "$code" != "200" ] && all_up=false && break
-    done
-    if $all_up; then echo -e " ${GREEN}✓${RESET}"; break; fi
-    sleep 5; elapsed=$((elapsed + 5)); echo -n "."
-    if [ $elapsed -ge 600 ]; then
-        echo
-        warn "Not all inference servers ready after 600 s — continuing anyway"
-        break
-    fi
-done
+check_inference || { stop_all; exit 1; }
 
 # ── 4. Orchestrator ───────────────────────────────────────────────────────────
 
@@ -95,9 +108,53 @@ section "Starting orchestrator..."
 tmux new-session -d -s agent -x 220 -y 50
 tmux rename-window -t agent:0 "orchestrator"
 tmux send-keys -t agent:0 "cd $DEMO_ROOT && pixi run orchestrator" Enter
-ok "Orchestrator launched  (agent)"
+log "Orchestrator launched  (agent)"
 
-# ── Summary ───────────────────────────────────────────────────────────────────
+# ── Final health check ────────────────────────────────────────────────────────
+
+section "Running health check in 10s..."
+sleep 10
+
+failed=false
+
+for s in simulation inference agent; do
+    if tmux has-session -t "$s" 2>/dev/null; then
+        ok "Session '$s' is running"
+    else
+        err "Session '$s' has exited unexpectedly"
+        failed=true
+    fi
+done
+
+for port in 8080 8081 8082 8083; do
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
+           "http://localhost:$port/health" 2>/dev/null || echo "000")
+    if [ "$code" = "200" ]; then
+        ok "Inference port $port — OK"
+    else
+        err "Inference port $port — not responding (HTTP $code)"
+        failed=true
+    fi
+done
+
+for topic in /clock /joint_states; do
+    if ros2 topic list 2>/dev/null | grep -q "^${topic}$"; then
+        ok "Topic ${topic} — OK"
+    else
+        err "Topic ${topic} — not found"
+        failed=true
+    fi
+done
+
+# ── Result ────────────────────────────────────────────────────────────────────
+
+if $failed; then
+    echo ""
+    echo -e "${BOLD}${RED}=== Demo failed — stopping all sessions ===${RESET}"
+    echo ""
+    stop_all
+    exit 1
+fi
 
 echo ""
 echo -e "${BOLD}${GREEN}=== Demo running ===${RESET}"

--- a/scripts/demo_stop.sh
+++ b/scripts/demo_stop.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+for s in simulation inference agent; do
+    tmux kill-session -t "$s" 2>/dev/null && echo "  killed '$s'" || true
+done

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -32,14 +32,10 @@ download "LFM2-VL-3B mmproj" \
     "https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/mmproj-LFM2-VL-3B-Q8_0.gguf?download=true" \
     "$MODELS_DIR/mmproj-LFM2-VL-3B-Q8_0.gguf"
 
-echo ""
-echo "=== Manual downloads required ==="
-echo ""
-echo "  The following models must be downloaded manually and placed in $MODELS_DIR/:"
-echo ""
-echo "  Qwen3-Embedding-0.6b:"
-echo "  https://robotecai-my.sharepoint.com/:u:/g/personal/bartlomiej_boczek_robotec_ai/IQB7tkMkmi34Q6xtTB89N1LxAfod0sMpGT4uTffjo6iW7qc?e=6kLoTi"
-echo ""
-echo "  Qwen3-Reranker-0.6B:"
-echo "  https://robotecai-my.sharepoint.com/:u:/g/personal/bartlomiej_boczek_robotec_ai/IQAgWOVPiyS8RZ1QUVVx6N9gAaOGGrvDnk7Qa0IpSbhlp_8?e=P0b1Ak"
-echo ""
+download "Qwen3-Embedding-0.6B (Embed)" \
+    "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf?download=true" \
+    "$MODELS_DIR/Qwen3-Embedding-0.6B-Q8_0.gguf"
+
+download "Qwen3-Reranker-0.6B (Rerank)" \
+    "https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/main/qwen3-reranker-0.6b-q8_0.gguf?download=true" \
+    "$MODELS_DIR/qwen3-reranker-0.6b-q8_0.gguf"

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+
+MODELS_DIR="${DEMO_ROOT}/models"
+mkdir -p "$MODELS_DIR"
+
+download() {
+    local name="$1"
+    local url="$2"
+    local dest="$3"
+    if [ -f "$dest" ]; then
+        echo "  [skip] $name — already exists"
+    else
+        echo "  [download] $name"
+        wget -q --show-progress -c -O "$dest" "$url"
+    fi
+}
+
+echo ""
+echo "=== Downloading models to $MODELS_DIR ==="
+echo ""
+
+download "GPT-OSS-20B (LLM)" \
+    "https://huggingface.co/unsloth/gpt-oss-20b-GGUF/resolve/main/gpt-oss-20b-Q4_K_M.gguf?download=true" \
+    "$MODELS_DIR/gpt-oss-20b-Q4_K_M.gguf"
+
+download "LFM2-VL-3B (VLM)" \
+    "https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/LFM2-VL-3B-Q8_0.gguf?download=true" \
+    "$MODELS_DIR/LFM2-VL-3B-Q8_0.gguf"
+
+download "LFM2-VL-3B mmproj" \
+    "https://huggingface.co/LiquidAI/LFM2-VL-3B-GGUF/resolve/main/mmproj-LFM2-VL-3B-Q8_0.gguf?download=true" \
+    "$MODELS_DIR/mmproj-LFM2-VL-3B-Q8_0.gguf"
+
+echo ""
+echo "=== Manual downloads required ==="
+echo ""
+echo "  The following models must be downloaded manually and placed in $MODELS_DIR/:"
+echo ""
+echo "  Qwen3-Embedding-0.6b:"
+echo "  https://robotecai-my.sharepoint.com/:u:/g/personal/bartlomiej_boczek_robotec_ai/IQB7tkMkmi34Q6xtTB89N1LxAfod0sMpGT4uTffjo6iW7qc?e=6kLoTi"
+echo ""
+echo "  Qwen3-Reranker-0.6B:"
+echo "  https://robotecai-my.sharepoint.com/:u:/g/personal/bartlomiej_boczek_robotec_ai/IQAgWOVPiyS8RZ1QUVVx6N9gAaOGGrvDnk7Qa0IpSbhlp_8?e=P0b1Ak"
+echo ""

--- a/scripts/run_ros2_stack.sh
+++ b/scripts/run_ros2_stack.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 (
   ros2 launch robotec_kairos_ur10 robotec_launch.py &
   ros2 run mobile_manipulator_hmi utilization_node &

--- a/scripts/serve_all.sh
+++ b/scripts/serve_all.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+SESSION="llm-servers"
+
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "Session '$SESSION' already exists. Attaching..."
+    tmux attach-session -t "$SESSION"
+    exit 0
+fi
+
+tmux new-session -d -s "$SESSION" -x 220 -y 50
+
+tmux rename-window -t "$SESSION:0" "inference"
+
+# 2x2 grid: split into 4 panes
+tmux split-window -h -t "$SESSION:0"
+tmux split-window -v -t "$SESSION:0.0"
+tmux split-window -v -t "$SESSION:0.2"
+
+tmux send-keys -t "$SESSION:0.0" "pixi run serve-llm" Enter
+tmux send-keys -t "$SESSION:0.1" "pixi run serve-embedding" Enter
+tmux send-keys -t "$SESSION:0.2" "pixi run serve-vlm" Enter
+tmux send-keys -t "$SESSION:0.3" "pixi run serve-reranker" Enter
+
+tmux select-layout -t "$SESSION:0" tiled
+
+tmux attach-session -t "$SESSION"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+RESET='\033[0m'
+
 PASS=0
 FAIL=0
 
 check() {
     local name="$1"
     local url="$2"
-    local response
     local http_code
 
     http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "$url" 2>/dev/null)
 
     if [ "$http_code" = "200" ]; then
-        echo "  [OK]   $name ($url)"
+        echo -e "  ${GREEN}[OK]   $name ($url)${RESET}"
         PASS=$((PASS + 1))
     else
-        echo "  [FAIL] $name ($url) — HTTP $http_code"
+        echo -e "  ${RED}[FAIL] $name ($url) — HTTP $http_code${RESET}"
         FAIL=$((FAIL + 1))
     fi
 }
@@ -24,13 +27,17 @@ echo ""
 echo "=== LLM Server Health Check ==="
 echo ""
 
-check "LLM   (GPT-OSS-20B)"        "http://localhost:8080/health"
-check "VLM   (LFM2-VL-3B)"         "http://localhost:8081/health"
+check "LLM   (GPT-OSS-20B)"          "http://localhost:8080/health"
+check "VLM   (LFM2-VL-3B)"           "http://localhost:8081/health"
 check "Embed (Qwen3-Embedding-0.6b)" "http://localhost:8082/health"
 check "Rerank (Qwen3-Reranker-0.6B)" "http://localhost:8083/health"
 
 echo ""
-echo "  $PASS passed, $FAIL failed"
+if [ "$FAIL" -eq 0 ]; then
+    echo -e "  ${GREEN}$PASS passed, $FAIL failed${RESET}"
+else
+    echo -e "  ${RED}$PASS passed, $FAIL failed${RESET}"
+fi
 echo ""
 
 [ "$FAIL" -eq 0 ]

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+PASS=0
+FAIL=0
+
+check() {
+    local name="$1"
+    local url="$2"
+    local response
+    local http_code
+
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "$url" 2>/dev/null)
+
+    if [ "$http_code" = "200" ]; then
+        echo "  [OK]   $name ($url)"
+        PASS=$((PASS + 1))
+    else
+        echo "  [FAIL] $name ($url) — HTTP $http_code"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo ""
+echo "=== LLM Server Health Check ==="
+echo ""
+
+check "LLM   (GPT-OSS-20B)"        "http://localhost:8080/health"
+check "VLM   (LFM2-VL-3B)"         "http://localhost:8081/health"
+check "Embed (Qwen3-Embedding-0.6b)" "http://localhost:8082/health"
+check "Rerank (Qwen3-Reranker-0.6B)" "http://localhost:8083/health"
+
+echo ""
+echo "  $PASS passed, $FAIL failed"
+echo ""
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
# feat: add pixi task runner to replace manual setup

This PR adds [pixi](https://pixi.sh), a package manager and task runner, to replace the previous 20-step manual setup process. `DEMO_ROOT` and `O3DE_ROOT` are now set automatically from the repo clone location — no `.bashrc` exports needed.

## What changed

- **`pixi.toml`** — defines all build and run tasks; single source of truth for the project workflow
- **`pixi_activate.sh`** — automatically sources ROS 2 Jazzy and the project workspace on every `pixi run` invocation
- **`pixi.lock`** — lockfile for reproducible environments
- **`scripts/download_models.sh`** — downloads all 5 models from HuggingFace automatically (embedding and reranker now included; SharePoint links removed)
- **`scripts/serve_all.sh`** — launches all 4 inference servers in a tmux 2×2 grid via `pixi run serve-all`
- **`scripts/smoke_test.sh`** — health-checks all inference endpoints with green/red color output
- **`config.toml`** — removed stale manual `llama-server` command comments
- **`pyproject.toml`** — added `tool.uv.workspace` to exclude `inference/` from uv workspace
- **`.gitignore`** — added `models/`
- **All setup and running docs** updated to use `pixi run` commands

## Setup (was: ~20 manual steps)

```bash
curl -fsSL https://pixi.sh/install.sh | sh  # install pixi once
pixi run setup                               # full single-machine setup
```

For the 3-machine demo setup:
- **Sim machine**: `pixi run setup`
- **HIL machine**: `pixi run setup-hil` (skips O3DE — no 30–60 min build)
- **HMI machine**: `pixi run setup-hil`

## Key improvements

- **No more `.bashrc` exports** — `DEMO_ROOT` and `O3DE_ROOT` are set from `$PIXI_PROJECT_ROOT`, so the repo works from any clone location
- **No more manual `source` calls** — ROS 2 environment is sourced automatically before every task
- **HIL-optimized setup** — `pixi run setup-hil` clones and builds only the ROS 2 workspace and Python dependencies, skipping O3DE entirely
- **Local inference** — `pixi run build-llama` / `pixi run setup-hil-local` replaces manual llama.cpp clone + cmake steps
- **Automated model downloads** — `pixi run download-models` fetches all 5 models from HuggingFace; embedding and reranker no longer require manual SharePoint downloads
- **Run tasks** — `pixi run sim`, `pixi run ros2`, `pixi run orchestrator`, etc. replace manual binary invocations and script calls
- **Smoke test** — `pixi run smoke-test` checks all inference server endpoints with color-coded output

## Available tasks

| Task | Description |
|------|-------------|
| `pixi run setup` | Full single-machine setup |
| `pixi run setup-hil` | HIL machine setup (ROS 2 + Python, no O3DE) |
| `pixi run setup-hil-local` | HIL setup + local llama.cpp inference |
| `pixi run setup-local` | Full setup + local llama.cpp inference |
| `pixi run build-llama` | Clone and build llama.cpp standalone |
| `pixi run download-models` | Download all 5 GGUF models from HuggingFace |
| `pixi run sim` | Launch O3DE simulation |
| `pixi run ros2` | Launch full ROS 2 stack |
| `pixi run orchestrator` | Launch agent orchestrator |
| `pixi run hmi` | Launch HMI |
| `pixi run serve-all` | Launch all 4 inference servers in a tmux 2×2 grid |
| `pixi run serve-llm` | Serve GPT-OSS-20B on port 8080 |
| `pixi run serve-vlm` | Serve LFM2-VL-3B on port 8081 |
| `pixi run serve-embedding` | Serve Qwen3-Embedding-0.6B on port 8082 |
| `pixi run serve-reranker` | Serve Qwen3-Reranker-0.6B on port 8083 |
| `pixi run smoke-test` | Health-check all inference servers |
| `pixi run lint` | Run all linters and formatters |
