### PR TITLE
fix: Update project to o3de 2605 and switch to o3de SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ imgui.ini
 anomaly_images/
 package_condition_images/
 models/
+*.bak0

--- a/docker/Dockerfile.agents
+++ b/docker/Dockerfile.agents
@@ -1,5 +1,4 @@
-ARG ROS2_IMAGE=robotecai/mobile-manipulator-demo-ros2:latest
-FROM ${ROS2_IMAGE}
+FROM base_image
 
 WORKDIR /root/MobileManipulatorDemo
 ENV DEMO_ROOT=/root/MobileManipulatorDemo

--- a/docker/Dockerfile.agents
+++ b/docker/Dockerfile.agents
@@ -4,16 +4,13 @@ FROM ${ROS2_IMAGE}
 WORKDIR /root/MobileManipulatorDemo
 ENV DEMO_ROOT=/root/MobileManipulatorDemo
 
-# install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
+COPY pixi.toml pixi.lock ./
+COPY pyproject.toml uv.lock ./
+COPY rai_app/ rai_app/
+COPY scripts/ scripts/
+COPY tests/ tests/
+COPY regulations_db/ regulations_db/
+COPY monitoring/ monitoring/
+COPY config.toml ./
 
-COPY pyproject.toml ${DEMO_ROOT}
-COPY rai_app/ ${DEMO_ROOT}/rai_app/
-COPY scripts/ ${DEMO_ROOT}/scripts/
-COPY tests/ ${DEMO_ROOT}/tests/
-COPY regulations_db/ ${DEMO_ROOT}/regulations_db/
-COPY monitoring/ ${DEMO_ROOT}/monitoring/
-COPY config.toml ${DEMO_ROOT}
-
-RUN uv sync
+RUN pixi run sync

--- a/docker/Dockerfile.o3de
+++ b/docker/Dockerfile.o3de
@@ -1,5 +1,4 @@
-ARG ROS2_IMAGE=mobile-manipulator-demo-ros2:latest
-FROM ${ROS2_IMAGE}
+FROM base_image
 
 # Install O3DE build dependencies and the 26.05 SDK
 # Note: git, git-lfs, ninja-build, ros-dev-tools, pixi are inherited from base image
@@ -38,6 +37,7 @@ COPY .git .git/
 COPY project_gems/ project_gems/
 COPY sim/ sim/
 
+RUN pixi run install-o3de
 RUN pixi run build-sim
 
 WORKDIR /root/MobileManipulatorDemo

--- a/docker/Dockerfile.o3de
+++ b/docker/Dockerfile.o3de
@@ -1,48 +1,44 @@
 ARG ROS2_IMAGE=mobile-manipulator-demo-ros2:latest
 FROM ${ROS2_IMAGE}
 
+# Install O3DE build dependencies and the 26.05 SDK
+# Note: git, git-lfs, ninja-build, ros-dev-tools, pixi are inherited from base image
+RUN apt update && apt install -y \
+    cmake \
+    libstdc++-12-dev \
+    clang \
+    libglu1-mesa-dev \
+    libxcb-randr0-dev \
+    libxcb-xinerama0 \
+    libxcb-xinput0 \
+    libxcb-xinput-dev \
+    libxcb-xfixes0-dev \
+    libxcb-xkb-dev \
+    libxkbcommon-dev \
+    libxkbcommon-x11-dev \
+    libfontconfig1-dev \
+    libpcre2-16-0 \
+    zlib1g-dev \
+    mesa-common-dev \
+    libunwind-dev \
+    libzstd-dev \
+    tix \
+    wget \
+    libxcb-keysyms1-dev \
+ && apt clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /root/MobileManipulatorDemo
-ENV DEMO_ROOT=/root/MobileManipulatorDemo
-ENV O3DE_ROOT=${DEMO_ROOT}/engine/o3de
 
-# Install O3DE dependencies
-# Note: git, git-lfs, ninja-build, ros-dev-tools are inherited from base image
-RUN apt update && apt install -y cmake libstdc++-12-dev clang libglu1-mesa-dev libxcb-randr0-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev tix
+# Refresh pixi task definitions so cmake flags, SDK path, etc. are current
+COPY pixi.toml pixi.lock gems.repos ros2_ws.repos ./
+COPY scripts/ scripts/
 
-# Copying .git to enable git lfs pull in gems directory
-COPY .git ${DEMO_ROOT}/.git
-COPY sim ${DEMO_ROOT}/sim
-COPY engine.repos ${DEMO_ROOT}/
-COPY gems.repos ${DEMO_ROOT}/
-COPY project_gems ${DEMO_ROOT}/project_gems
+# .git is required for gems LFS pull inside register-project
+COPY .git .git/
+COPY project_gems/ project_gems/
+COPY sim/ sim/
 
-# ---- O3DE ---- # 
-RUN vcs import --input ${DEMO_ROOT}/engine.repos
-RUN vcs import --input ${DEMO_ROOT}/gems.repos
+RUN pixi run build-sim
 
-WORKDIR ${O3DE_ROOT}
-RUN git lfs install
-RUN git lfs pull
-RUN python/get_python.sh
-RUN ${O3DE_ROOT}/scripts/o3de.sh register --this-engine
-
-WORKDIR ${DEMO_ROOT}/gems
-RUN git lfs install --force
-RUN git lfs pull
-
-# ---- Build O3DE ---- # 
-
-WORKDIR ${DEMO_ROOT}/sim
-RUN . ${DEMO_ROOT}/ros2_ws/install/setup.sh && cmake -B build/linux -G "Ninja Multi-Config" \
-    -DLY_DISABLE_TEST_MODULES=ON \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DLY_STRIP_DEBUG_SYMBOLS=ON \
-    -DCMAKE_LINKER_TYPE=MOLD
-RUN . ${DEMO_ROOT}/ros2_ws/install/setup.sh && cmake --build build/linux --config profile --target MobileManipulatorDemo Editor MobileManipulatorDemo.Assets MobileManipulatorDemo.GameLauncher
-
-# clear up apt cache
-RUN apt clean
-RUN rm -rf /var/lib/apt/lists/*
-
-WORKDIR ${DEMO_ROOT}
+WORKDIR /root/MobileManipulatorDemo
 CMD ["bash"]

--- a/docker/Dockerfile.o3de
+++ b/docker/Dockerfile.o3de
@@ -38,6 +38,7 @@ COPY project_gems/ project_gems/
 COPY sim/ sim/
 
 RUN pixi run install-o3de
+RUN apt install -y git-lfs && git lfs install --force
 RUN pixi run build-sim
 
 WORKDIR /root/MobileManipulatorDemo

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -23,6 +23,7 @@ ENV DEMO_ROOT=/root/MobileManipulatorDemo
 
 COPY pixi.toml pixi.lock ros2_ws.repos ./
 COPY scripts/ scripts/
+COPY ros2_ws/ ros2_ws/
 
 RUN rosdep init && pixi run build-ros2
 

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -1,23 +1,29 @@
 FROM ros:jazzy-ros-core
 
+RUN apt update && apt install -y --no-install-recommends \
+    curl \
+    python3-vcstool \
+    git \
+    git-lfs \
+    ninja-build \
+    ros-dev-tools \
+    lsb-release \
+    wget \
+    gnupg
+
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+RUN apt update
+RUN apt install -y libgz-math7-dev
+
+RUN curl -fsSL https://pixi.sh/install.sh | PIXI_HOME=/usr/local bash
+
 WORKDIR /root/MobileManipulatorDemo
 ENV DEMO_ROOT=/root/MobileManipulatorDemo
-RUN apt update && apt install -y python3-vcstool git git-lfs ninja-build ros-dev-tools
-RUN rosdep init
 
-COPY ros2_ws.repos ${DEMO_ROOT}
-COPY ros2_ws/src ${DEMO_ROOT}/ros2_ws/src
+COPY pixi.toml pixi.lock ros2_ws.repos ./
+COPY scripts/ scripts/
 
-WORKDIR ${DEMO_ROOT}
-RUN vcs import --input ${DEMO_ROOT}/ros2_ws.repos
+RUN rosdep init && pixi run build-ros2
 
-WORKDIR ${DEMO_ROOT}/ros2_ws
-RUN rosdep update
-RUN rosdep install --ignore-src --from-paths src -y
-RUN . /opt/ros/${ROS_DISTRO}/setup.sh && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 RUN echo "source ${DEMO_ROOT}/ros2_ws/install/setup.bash" >> ~/.bashrc
-
-RUN apt clean
-RUN rm -rf /var/lib/apt/lists/*
-
-WORKDIR ${DEMO_ROOT}

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -16,8 +16,10 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority
     entrypoint: /ros_entrypoint.sh
-    command: pixi run sim
+    command: >
+      sh -c 'find /root/MobileManipulatorDemo/sim/Cache -type f -exec sh -c '"'"'cat "$@" > /dev/null'"'"' sh {} + && pixi run sim'
     networks:
+
       - ros2_bridge
 
   ros2:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -4,8 +4,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.o3de
-      args:
-        ROS2_IMAGE: mobile-manipulator-demo-ros2:latest
+      additional_contexts:
+        base_image: service:ros2
     environment:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
@@ -15,14 +15,13 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority
-      - ./start_sim.sh:/root/MobileManipulatorDemo/start_sim.sh
     entrypoint: /ros_entrypoint.sh
-    command: /root/MobileManipulatorDemo/start_sim.sh
+    command: pixi run sim
     networks:
       - ros2_bridge
 
   ros2:
-    image: mobile-manipulator-demo-ros2:latest
+    image: robotecai/mobile-manipulator-demo-ros2:latest
     build:
       context: ..
       dockerfile: docker/Dockerfile.ros2
@@ -32,6 +31,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.agents
+      additional_contexts:
+        base_image: service:ros2
     environment:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
@@ -44,47 +45,53 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority
       - ../config.toml:/root/MobileManipulatorDemo/config.toml
+    command: pixi run ros2
     networks:
       - ros2_bridge
 
-  hmi:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && ros2 launch mobile_manipulator_hmi hmi_launch.py"
+  # hmi:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && ros2 launch mobile_manipulator_hmi hmi_launch.py"
 
-  kairos:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && ros2 launch robotec_kairos_ur10 robotec_launch.py"
+  # kairos:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && ros2 launch robotec_kairos_ur10 robotec_launch.py"
 
-  utilization_node:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && ros2 run manipulator_hmi utilization_node"
+  # utilization_node:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && ros2 run manipulator_hmi utilization_node"
 
-  nav2_agent:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/nav2_agent.py"
+  # nav2_agent:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/nav2_agent.py"
 
-  moveit2_agent:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/moveit2_agent.py"
+  # moveit2_agent:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/moveit2_agent.py"
 
-  scene_agent:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/environment/scene_agent.py"
+  # scene_agent:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/environment/scene_agent.py"
 
-  nav_lifecycle_node:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && ros2 run nav2_lifecycle_manager nav_lifecycle_node"
+  # nav_lifecycle_node:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && ros2 run nav2_lifecycle_manager nav_lifecycle_node"
 
-  inspection_agent:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/inspection_agent.py"
+  # inspection_agent:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/inspection_agent.py"
 
-  safety_agent:
-    <<: *stack
-    command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && cd /root/MobileManipulatorDemo && ./scripts/start_safety_agent.sh"
+  # safety_agent:
+  #   <<: *stack
+  #   command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && cd /root/MobileManipulatorDemo && ./scripts/start_safety_agent.sh"
 
   agents:
     image: robotecai/mobile-manipulator-demo-agents:latest
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.agents
+      additional_contexts:
+        base_image: service:ros2
     environment:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
@@ -96,25 +103,25 @@ services:
       - ../cloud_config.toml:/root/MobileManipulatorDemo/config.toml
 
     entrypoint: /ros_entrypoint.sh
-    command: bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/agent_orchestrator.py"
+    command: pixi run orchestrator
     networks:
       - ros2_bridge
 
-  safety-embeddings:
-    image: robotecai/mobile-manipulator-demo-llama:latest
-    build:
-      dockerfile: Dockerfile.llama
-    command: -m /custom_ggufs/Qwen3-Embedding-0.6b_BF16.gguf --embedding -c 4096 -b 2048 -ub 2048 --pooling last --port 8082 --host 0.0.0.0
-    networks:
-      - ros2_bridge
+  # safety-embeddings:
+  #   image: robotecai/mobile-manipulator-demo-llama:latest
+  #   build:
+  #     dockerfile: Dockerfile.llama
+  #   command: -m /custom_ggufs/Qwen3-Embedding-0.6b_BF16.gguf --embedding -c 4096 -b 2048 -ub 2048 --pooling last --port 8082 --host 0.0.0.0
+  #   networks:
+  #     - ros2_bridge
 
-  safety-reranker:
-    image: robotecai/mobile-manipulator-demo-llama:latest
-    build:
-      dockerfile: Dockerfile.llama
-    command: -m /custom_ggufs/Qwen3-Reranker-0.6B_16BF.gguf --embedding --pooling rank -fa on -c 4096 -b 2048 -ub 2048 --port 8083 --host 0.0.0.0
-    networks:
-      - ros2_bridge
+  # safety-reranker:
+  #   image: robotecai/mobile-manipulator-demo-llama:latest
+  #   build:
+  #     dockerfile: Dockerfile.llama
+  #   command: -m /custom_ggufs/Qwen3-Reranker-0.6B_16BF.gguf --embedding --pooling rank -fa on -c 4096 -b 2048 -ub 2048 --port 8083 --host 0.0.0.0
+  #   networks:
+  #     - ros2_bridge
 networks:
   ros2_bridge:
     driver: bridge

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,6 +1,11 @@
 services:
   sim:
     image: robotecai/mobile-manipulator-demo-o3de:latest
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.o3de
+      args:
+        ROS2_IMAGE: mobile-manipulator-demo-ros2:latest
     environment:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
@@ -16,8 +21,17 @@ services:
     networks:
       - ros2_bridge
 
+  ros2:
+    image: mobile-manipulator-demo-ros2:latest
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.ros2
+
   stack: &stack
     image: robotecai/mobile-manipulator-demo-agents:latest
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.agents
     environment:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
@@ -29,7 +43,7 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority
-      - ../config.toml:/root/MobileManipulatorDemo/config.toml 
+      - ../config.toml:/root/MobileManipulatorDemo/config.toml
     networks:
       - ros2_bridge
 
@@ -48,7 +62,7 @@ services:
   nav2_agent:
     <<: *stack
     command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/nav2_agent.py"
-  
+
   moveit2_agent:
     <<: *stack
     command: /bin/bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/moveit2_agent.py"
@@ -79,7 +93,7 @@ services:
       - /dev/kfd:/dev/kfd
       - /dev/dri:/dev/dri
     volumes:
-      - ../cloud_config.toml:/root/MobileManipulatorDemo/config.toml 
+      - ../cloud_config.toml:/root/MobileManipulatorDemo/config.toml
 
     entrypoint: /ros_entrypoint.sh
     command: bash -c "source /root/MobileManipulatorDemo/ros2_ws/install/setup.bash && uv run python rai_app/agents/agent_orchestrator.py"

--- a/docs/setup_sim.md
+++ b/docs/setup_sim.md
@@ -58,10 +58,10 @@ This single command runs the full build pipeline in the correct order:
 | 1    | `clone-gems`       | `vcs import` for local O3DE gems                      |
 | 2    | `clone-ros2-ws`    | `vcs import` for the ROS 2 workspace                  |
 | 3    | `install-o3de`     | Install the O3DE engine                               |
-| 4    | `register-gems`    | Register O3DE gems                              |
-| 5    | `register-project` | Run `git lfs pull` and register the simulation project |
+| 4    | `register-gems`    | Register O3DE gems                                    |
+| 5    | `register-project` | Run `git lfs pull` and register the simulation project|
 | 6    | `build-ros2`       | `rosdep install` + `colcon build`                     |
-| 7    | `build-sim`        | CMake configure + Ninja build (Editor + GameLauncher) |
+| 7    | `build-sim`        | CMake configure + Ninja build (GameLauncher)          |
 | 8    | `sync`             | `uv sync` — install Python dependencies               |
 
 

--- a/docs/setup_sim.md
+++ b/docs/setup_sim.md
@@ -53,17 +53,17 @@ pixi run setup
 
 This single command runs the full build pipeline in the correct order:
 
-| Step | pixi task       | What it does                                          |
-| ---- | --------------- | ----------------------------------------------------- |
-| 1    | `clone-engine`  | `vcs import` for O3DE engine and gems                 |
-| 2    | `clone-ros2-ws` | `vcs import` for ROS 2 workspace                      |
-| 3    | `setup-o3de`    | git-lfs pull + O3DE engine registration               |
-| 4    | `register-gems` | Register all O3DE gems and the simulation project     |
-| 5    | `build-ros2`    | `rosdep install` + `colcon build`                     |
-| 6    | `build-o3de`    | CMake configure + Ninja build (Editor + GameLauncher) |
-| 7    | `sync`          | `uv sync` — install Python dependencies               |
+| Step | pixi task          | What it does                                          |
+| ---- | ------------------ | ----------------------------------------------------- |
+| 1    | `clone-gems`       | `vcs import` for local O3DE gems                      |
+| 2    | `clone-ros2-ws`    | `vcs import` for the ROS 2 workspace                  |
+| 3    | `install-o3de`     | Install the O3DE engine                               |
+| 4    | `register-gems`    | Register O3DE gems                              |
+| 5    | `register-project` | Run `git lfs pull` and register the simulation project |
+| 6    | `build-ros2`       | `rosdep install` + `colcon build`                     |
+| 7    | `build-sim`        | CMake configure + Ninja build (Editor + GameLauncher) |
+| 8    | `sync`             | `uv sync` — install Python dependencies               |
 
-> [!NOTE] > `build-o3de` takes 30–60 minutes on first run.
 
 ---
 

--- a/docs/setup_single_machine.md
+++ b/docs/setup_single_machine.md
@@ -56,14 +56,15 @@ pixi run setup
 
 This single command runs the full build pipeline in the correct order:
 
-| Step | pixi task       | What it does                                          |
-| ---- | --------------- | ----------------------------------------------------- |
-| 1    | `clone`         | `vcs import` for engine, gems, and ROS 2 workspace    |
-| 2    | `setup-o3de`    | git-lfs pull + O3DE engine registration               |
-| 3    | `register-gems` | Register all O3DE gems and the simulation project     |
-| 4    | `build-ros2`    | `rosdep install` + `colcon build`                     |
-| 5    | `build-o3de`    | CMake configure + Ninja build (Editor + GameLauncher) |
-| 6    | `sync`          | `uv sync` — install Python dependencies               |
+| Step | pixi task          | What it does                                          |
+| ---- | ------------------ | ----------------------------------------------------- |
+| 1    | `clone`            | `vcs import` for gems and the ROS 2 workspace         |
+| 2    | `install-o3de`     | Install the O3DE engine                               |
+| 3    | `register-gems`    | Register O3DE gems                              |
+| 4    | `register-project` | Run `git lfs pull` and register the simulation project |
+| 5    | `build-ros2`       | `rosdep install` + `colcon build`                     |
+| 6    | `build-sim`        | CMake configure + Ninja build (Editor + GameLauncher) |
+| 7    | `sync`             | `uv sync` — install Python dependencies               |
 
 #### Local Inference (optional)
 

--- a/docs/setup_single_machine.md
+++ b/docs/setup_single_machine.md
@@ -60,10 +60,10 @@ This single command runs the full build pipeline in the correct order:
 | ---- | ------------------ | ----------------------------------------------------- |
 | 1    | `clone`            | `vcs import` for gems and the ROS 2 workspace         |
 | 2    | `install-o3de`     | Install the O3DE engine                               |
-| 3    | `register-gems`    | Register O3DE gems                              |
-| 4    | `register-project` | Run `git lfs pull` and register the simulation project |
+| 3    | `register-gems`    | Register O3DE gems                                    |
+| 4    | `register-project` | Run `git lfs pull` and register the simulation project|
 | 5    | `build-ros2`       | `rosdep install` + `colcon build`                     |
-| 6    | `build-sim`        | CMake configure + Ninja build (Editor + GameLauncher) |
+| 6    | `build-sim`        | CMake configure + Ninja build (GameLauncher)          |
 | 7    | `sync`             | `uv sync` — install Python dependencies               |
 
 #### Local Inference (optional)

--- a/engine.repos
+++ b/engine.repos
@@ -1,5 +1,5 @@
 repositories:
   ./engine/o3de:
     type: git
-    url: https://github.com/RobotecAI/o3de.git
-    version: 725882d7a09d4c3f204a6256f5a79e839e33ea0c
+    url: https://github.com/o3de/o3de.git
+    version: 2605.0

--- a/engine.repos
+++ b/engine.repos
@@ -1,5 +1,0 @@
-repositories:
-  ./engine/o3de:
-    type: git
-    url: https://github.com/o3de/o3de.git
-    version: 2605.0

--- a/gems.repos
+++ b/gems.repos
@@ -1,8 +1,4 @@
 repositories:
-  ./gems/o3de-extras:
-    type: git
-    url: https://github.com/o3de/o3de-extras.git
-    version: 2605.0
   ./gems/o3de-humanworker-gem:
     type: git
     url: https://github.com/RobotecAI/o3de-humanworker-gem.git

--- a/gems.repos
+++ b/gems.repos
@@ -1,20 +1,20 @@
 repositories:
   ./gems/o3de-extras:
     type: git
-    url: https://github.com/robotecai/o3de-extras.git
-    version: a653caeb431a3cf2da26c227b57c0fc1829fefcd
+    url: https://github.com/o3de/o3de-extras.git
+    version: 2605.0
   ./gems/o3de-humanworker-gem:
     type: git
     url: https://github.com/RobotecAI/o3de-humanworker-gem.git
-    version: f7bcf0f78383a30d60947de30e06971f15682ce6
+    version: 3.0.0
   ./gems/o3de-ur-robots-gem:
     type: git
     url: https://github.com/RobotecAI/o3de-ur-robots-gem.git
-    version: 33fc9f1f0629d7d8dd5378958dae774434c9334d
+    version: 3.0.0
   ./gems/robotec-o3de-tools:
     type: git
     url: https://github.com/RobotecAI/robotec-o3de-tools.git
-    version: b88b11f3de7185197a4b396d51c6b00c1283d51a
+    version: f8ff72cc2fd249f77c16c5cf43d4341dccc29633
   ./gems/robotec-warehouse-assets:
     type: git
     url: https://github.com/RobotecAI/robotec-warehouse-assets.git

--- a/pixi.toml
+++ b/pixi.toml
@@ -211,3 +211,7 @@ description = "Run all linters and formatters"
 [tasks.test]
 cmd = "uv run pytest"
 description = "Run test suite"
+
+[tasks.editor]
+cmd = "$DEMO_ROOT/sim/build/linux/bin/profile/Editor"
+description = "Launch O3DE editor"

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,11 +6,10 @@ channels = ["conda-forge"]
 platforms = ["linux-64"]
 
 # ─── Environment ────────────────────────────────────────────────────────────────
-# DEMO_ROOT and O3DE_ROOT are set automatically — no need to add them to .bashrc.
 # pixi_activate.sh sources ROS 2 setup files when available.
 [activation]
-env = { DEMO_ROOT = "${PIXI_PROJECT_ROOT}", O3DE_ROOT = "${PIXI_PROJECT_ROOT}/engine/o3de" }
-scripts = ["pixi_activate.sh"]
+env = {DEMO_ROOT = "${PIXI_PROJECT_ROOT}"}
+scripts = ["scripts/setup_env.sh"]
 
 [dependencies]
 # uv is the Python package manager used by this project.
@@ -20,41 +19,37 @@ uv = ">=0.5"
 
 # ─── Setup Tasks ────────────────────────────────────────────────────────────────
 
-[tasks.clone-engine]
+[tasks.install-o3de]
+cmd = "scripts/install_o3de.sh"
+
+[tasks.clone-gems]
 cmd = """
-vcs import --input $DEMO_ROOT/engine.repos &&
 vcs import --input $DEMO_ROOT/gems.repos
 """
-description = "Clone O3DE engine and gems"
+description = "Clone local O3DE gems"
 
 [tasks.clone-ros2-ws]
 cmd = "vcs import --input $DEMO_ROOT/ros2_ws.repos"
 description = "Clone ROS 2 workspace repositories"
 
 [tasks.clone]
-depends-on = ["clone-engine", "clone-ros2-ws"]
-description = "Clone all repositories (engine, gems, and ROS 2 workspace)"
+depends-on = ["clone-gems", "clone-ros2-ws"]
+description = "Clone all repositories (gems and ROS 2 workspace)"
 
 [tasks.clone-inference]
 cmd = "vcs import --input $DEMO_ROOT/inference.repos"
 description = "Clone llama.cpp (required for local inference)"
 
-[tasks.setup-o3de]
-cmd = """
-cd $O3DE_ROOT &&
-git lfs install && git lfs pull &&
-python/get_python.sh &&
-$O3DE_ROOT/scripts/o3de.sh register --this-engine
-"""
-depends-on = ["clone-engine"]
-description = "Pull O3DE LFS assets and register the engine"
+[tasks.register-gems]
+cmd = "scripts/register_gems.sh"
+depends-on = ["clone-gems", "install-o3de"]
 
 [tasks.register-project]
 cmd = """
 cd $DEMO_ROOT/gems && git lfs install && git lfs pull &&
-$O3DE_ROOT/scripts/o3de.sh register --project-path $DEMO_ROOT/sim --force
+$O3DE_ENGINE_PATH/scripts/o3de.sh register --project-path $DEMO_ROOT/sim --force
 """
-depends-on = ["setup-o3de"]
+depends-on = ["install-o3de"]
 description = "Register the simulation project"
 
 [tasks.build-ros2]
@@ -67,7 +62,7 @@ colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 depends-on = ["clone-ros2-ws"]
 description = "Build the ROS 2 workspace with colcon"
 
-[tasks.build-o3de]
+[tasks.build-sim]
 cmd = """
 cd $DEMO_ROOT/sim &&
 cmake -B build/linux -G "Ninja Multi-Config" \
@@ -79,8 +74,8 @@ cmake -B build/linux -G "Ninja Multi-Config" \
 cmake --build build/linux --config profile \
     --target MobileManipulatorDemo Editor MobileManipulatorDemo.Assets MobileManipulatorDemo.GameLauncher
 """
-depends-on = ["register-project", "build-ros2"]
-description = "Build O3DE Editor and GameLauncher (slow — takes 30–60 min)"
+depends-on = ["register-gems", "register-project", "build-ros2"]
+description = "Build O3DE Editor and GameLauncher"
 
 [tasks.build-llama]
 cmd = """
@@ -98,7 +93,7 @@ description = "Install Python dependencies"
 # Full setup: runs all build steps in dependency order.
 # Run pixi run setup-local if you also need local llama.cpp inference.
 [tasks.setup]
-depends-on = ["build-ros2", "build-o3de", "sync"]
+depends-on = ["build-ros2", "build-sim", "sync"]
 description = "Full setup (O3DE + ROS 2 + Python). See also: setup-local."
 
 [tasks.setup-hil]
@@ -131,6 +126,10 @@ description = "Launch the Human-Machine Interface"
 [tasks.orchestrator]
 cmd = "uv run python rai_app/agents/agent_orchestrator.py"
 description = "Launch the agent orchestrator"
+
+[tasks.editor]
+cmd = "$O3DE_ENGINE_PATH/bin/Linux/profile/Default/Editor"
+description = "Launch O3DE editor"
 
 # Individual agents — use these instead of ros2 when debugging a specific component.
 [tasks.nav2-agent]
@@ -211,7 +210,3 @@ description = "Run all linters and formatters"
 [tasks.test]
 cmd = "uv run pytest"
 description = "Run test suite"
-
-[tasks.editor]
-cmd = "$DEMO_ROOT/sim/build/linux/bin/profile/Editor"
-description = "Launch O3DE editor"

--- a/rai_app/environment/scene_manager.py
+++ b/rai_app/environment/scene_manager.py
@@ -235,7 +235,7 @@ class SceneManager:
 
         req = SpawnEntity.Request()
         req.name = name
-        req.entity_resource.uri = self.spawnable_to_uri[object_name]
+        req.uri = self.spawnable_to_uri[object_name]
         req.initial_pose.header.frame_id = frame
         req.initial_pose.pose.position.x = pose.position.x
         req.initial_pose.pose.position.y = pose.position.y

--- a/rai_app/environment/scene_manager.py
+++ b/rai_app/environment/scene_manager.py
@@ -235,7 +235,7 @@ class SceneManager:
 
         req = SpawnEntity.Request()
         req.name = name
-        req.uri = self.spawnable_to_uri[object_name]
+        req.entity_resource.uri = self.spawnable_to_uri[object_name]
         req.initial_pose.header.frame_id = frame
         req.initial_pose.pose.position.x = pose.position.x
         req.initial_pose.pose.position.y = pose.position.y

--- a/ros2_ws.repos
+++ b/ros2_ws.repos
@@ -18,7 +18,7 @@ repositories:
   ros2_ws/src/packages/simulation_interfaces:
     type: git
     url: https://github.com/ros-simulation/simulation_interfaces.git
-    version: 1.0.1
+    version: 2.1.0
   ros2_ws/src/packages/rai_interfaces:
     type: git
     url: https://github.com/RobotecAI/rai_interfaces.git

--- a/ros2_ws.repos
+++ b/ros2_ws.repos
@@ -18,7 +18,7 @@ repositories:
   ros2_ws/src/packages/simulation_interfaces:
     type: git
     url: https://github.com/ros-simulation/simulation_interfaces.git
-    version: 2.1.0
+    version: 1.5.1
   ros2_ws/src/packages/rai_interfaces:
     type: git
     url: https://github.com/RobotecAI/rai_interfaces.git

--- a/scripts/install_o3de.sh
+++ b/scripts/install_o3de.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# O3DE SDK .deb download URL. Override with the O3DE_DEB_URL env var.
+O3DE_DEB_URL="${O3DE_DEB_URL:-https://o3debinaries.org/main/Latest/Linux/o3de_2605_0.deb}"
+O3DE_REQUIRED_VERSION="26.05"
+
+# ── Step 1: Install the .deb package ────────────────────────────────────────
+
+# Check whether the required version is already installed. There may be
+# multiple versions under /opt/O3DE/; only a directory whose name contains
+# the required version string (e.g. "26.05") satisfies the check.
+if ls -d /opt/O3DE/*/ &>/dev/null && \
+       ls -d /opt/O3DE/*/ | grep -q "$O3DE_REQUIRED_VERSION"; then
+    echo "O3DE SDK $O3DE_REQUIRED_VERSION already installed: $(ls -d /opt/O3DE/*/ | grep "$O3DE_REQUIRED_VERSION")"
+else
+    if ls -d /opt/O3DE/*/ &>/dev/null; then
+        echo "O3DE SDK found but version $O3DE_REQUIRED_VERSION is required. Installed: $(ls -d /opt/O3DE/*/)"
+    fi
+    echo "Downloading O3DE SDK from: $O3DE_DEB_URL"
+    TMP_DEB=$(mktemp --suffix=.deb)
+    trap 'rm -f "$TMP_DEB"' EXIT
+
+    curl -fsSL -o "$TMP_DEB" "$O3DE_DEB_URL"
+    chmod 644 "$TMP_DEB"
+
+    echo "Installing O3DE SDK (requires sudo)..."
+    sudo apt-get install -y "$TMP_DEB"
+
+    echo "O3DE SDK installed: $(ls -d /opt/O3DE/*/)"
+fi
+
+O3DE_ENGINE=$(ls -d /opt/O3DE/*/ | grep "$O3DE_REQUIRED_VERSION" | head -1 | sed 's:/$::')
+
+# ── Step 2: Bootstrap O3DE's bundled Python ─────────────────────────────────
+# The .deb does not ship Python; get_python.sh downloads it and creates a
+# venv. Needed before o3de.sh (which is a Python wrapper) can run.
+
+if [[ -d "$HOME/.o3de/Python/packages" ]]; then
+    echo "O3DE Python already bootstrapped."
+else
+    echo "Bootstrapping O3DE Python..."
+    "$O3DE_ENGINE/python/get_python.sh"
+fi
+
+# ── Step 3: Register the engine ─────────────────────────────────────────────
+# Makes the SDK discoverable by cmake and o3de.sh project commands.
+
+if grep -q "$O3DE_ENGINE" ~/.o3de/o3de_manifest.json 2>/dev/null; then
+    echo "O3DE engine already registered."
+else
+    echo "Registering O3DE engine..."
+    "$O3DE_ENGINE/scripts/o3de.sh" register --this-engine
+fi
+
+echo "O3DE SDK ready: $O3DE_ENGINE"

--- a/scripts/register_gems.sh
+++ b/scripts/register_gems.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Downloads released gems from the O3DE gem catalogue and registers local
+# submodule gems with the O3DE engine.
+# Requires O3DE_ENGINE_PATH to be set (done automatically by pixi activation).
+# Run after fetch-deps: pixi run register-gems
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPS_DIR="$PROJECT_ROOT/deps"
+O3DE_CLI="$O3DE_ENGINE_PATH/scripts/o3de.sh"
+
+if [[ ! -f "$O3DE_CLI" ]]; then
+    echo "ERROR: O3DE CLI not found at $O3DE_CLI"
+    echo "       Make sure O3DE is installed and O3DE_ENGINE_PATH is set correctly."
+    exit 1
+fi
+
+# ── Step 1: Register the gem repo ───────────────────────────────────────────
+# Required so that `o3de download` can resolve gem names to download URLs.
+
+O3DE_REPO_URI="https://canonical.o3de.org"
+if grep -q "$O3DE_REPO_URI" ~/.o3de/o3de_manifest.json 2>/dev/null; then
+    echo "O3DE gem repo already registered."
+else
+    echo "Registering O3DE gem repo: $O3DE_REPO_URI"
+    "$O3DE_CLI" register --repo-uri "$O3DE_REPO_URI"
+fi
+
+# ── Step 2: Download released gems from the gem catalogue ───────────────────
+
+RELEASED_GEMS=(
+    "ROS2==4.2.0"
+    "ROS2Sensors==1.0.1"
+    "ROS2Controllers==1.1.0"
+    "LevelGeoreferencing==1.0.0"
+    "ROS2SampleRobots==1.2.0"
+    "SimulationInterfaces==2.2.0"
+    "WarehouseAssets==2.0.4"
+)
+
+echo "=== Downloading O3DE Gems ==="
+for gem in "${RELEASED_GEMS[@]}"; do
+    echo "  Downloading: $gem"
+    "$O3DE_CLI" download --gem-name "$gem" -f
+done
+
+# ── Step 3: Register local submodule gems ───────────────────────────────────
+
+register_gem() {
+    local gem_path="$1"
+    if [[ ! -d "$gem_path" ]]; then
+        echo "ERROR: Gem directory not found: $gem_path"
+        echo "       Run 'pixi run fetch-deps' first."
+        exit 1
+    fi
+    echo "  Registering: $gem_path"
+    "$O3DE_CLI" register --gem-path "$gem_path"
+}
+
+echo ""
+echo "=== All gems downloaded and registered successfully ==="

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -3,6 +3,18 @@
 # Sets up ROS 2 Jazzy paths so that pixi shell / pixi run tasks have a full
 # ROS 2 environment without needing manual `source` calls.
 
+# O3DE SDK path — resolved in order:
+#   1. Caller-set env var (native dev workflow)
+#   2. /etc/o3de-engine-path written by the container build (actual install path)
+#   3. Hardcoded fallback for a typical native install
+if [[ -z "$O3DE_ENGINE_PATH" ]]; then
+    if [[ -f /etc/o3de-engine-path ]]; then
+        export O3DE_ENGINE_PATH=$(cat /etc/o3de-engine-path)
+    else
+        export O3DE_ENGINE_PATH=/opt/O3DE/26.05
+    fi
+fi
+
 # Base ROS 2 installation
 if [ -f "/opt/ros/jazzy/local_setup.sh" ]; then
     # shellcheck source=/dev/null

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -5,14 +5,10 @@
 
 # O3DE SDK path — resolved in order:
 #   1. Caller-set env var (native dev workflow)
-#   2. /etc/o3de-engine-path written by the container build (actual install path)
-#   3. Hardcoded fallback for a typical native install
+#   2. Discovered from /opt/O3DE/ (set by install_o3de.sh or container build)
 if [[ -z "$O3DE_ENGINE_PATH" ]]; then
-    if [[ -f /etc/o3de-engine-path ]]; then
-        export O3DE_ENGINE_PATH=$(cat /etc/o3de-engine-path)
-    else
-        export O3DE_ENGINE_PATH=/opt/O3DE/26.05
-    fi
+    discovered=$(ls -d /opt/O3DE/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')
+    [[ -n "$discovered" ]] && export O3DE_ENGINE_PATH="$discovered"
 fi
 
 # Base ROS 2 installation

--- a/sim/Gem/CMakeLists.txt
+++ b/sim/Gem/CMakeLists.txt
@@ -12,13 +12,22 @@ include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 # Now that we have loaded our project traits for this platform, see if this project is even supported on this platform.
 # If its not supported we just return after including the unsupported.
 if(NOT PAL_TRAIT_MOBILEMANIPULATORDEMO_SUPPORTED)
-    return()
+  return()
 endif()
 
 # We are on a supported platform, so add the ${gem_name} target
 # Note: We include the common files and the platform specific files which are set in mobilemanipulatordemo_files.cmake and
 # in ${pal_dir}/mobilemanipulatordemo_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
 
+find_package(simulation_interfaces REQUIRED)
+if(simulation_interfaces_VERSION VERSION_GREATER_EQUAL "2.0.0")
+  set(SIMULATION_INTERFACES_MAJOR_API_VERSION 2)
+elseif(simulation_interfaces_VERSION VERSION_GREATER_EQUAL "1.4.0")
+  set(SIMULATION_INTERFACES_MAJOR_API_VERSION 1)
+else()
+  message(FATAL_ERROR "simulation_interfaces version ${simulation_interfaces_VERSION} is not supported. Minimum required: 1.4.0")
+endif()
+message(STATUS "simulation_interfaces ${simulation_interfaces_VERSION} -> SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION}")
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this CMakeLists.txt
 ly_add_target(
@@ -34,7 +43,12 @@ ly_add_target(
         PRIVATE
             AZ::AzGameFramework
             Gem::Atom_AtomBridge.Static
+            Gem::SimulationInterfaces.API
+            Gem::ROS2.Static
 )
+target_compile_definitions(${gem_name}.Private.Object PUBLIC
+    SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION})
+
 
 ly_add_target(
     NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
@@ -49,6 +63,8 @@ ly_add_target(
         PRIVATE
             Gem::${gem_name}.Private.Object
             AZ::AzCore
+            Gem::SimulationInterfaces.API
+            Gem::ROS2.Static
 )
 
 # Include the gem name into the Client Module source file
@@ -87,5 +103,5 @@ o3de_find_ancestor_project_root(project_path project_name "${CMAKE_CURRENT_SOURC
 # If the project name could not be queried from a project.json file, then fallback
 # to using the name of the project provided when the project template was instantiated
 if (NOT project_name)
-    set(project_name MobileManipulatorDemo)
+  set(project_name MobileManipulatorDemo)
 endif()

--- a/sim/Gem/CMakeLists.txt
+++ b/sim/Gem/CMakeLists.txt
@@ -44,7 +44,7 @@ ly_add_target(
             AZ::AzGameFramework
             Gem::Atom_AtomBridge.Static
             Gem::SimulationInterfaces.API
-            Gem::ROS2.Static
+            Gem::ROS2.API
 )
 target_compile_definitions(${gem_name}.Private.Object PUBLIC
     SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION})
@@ -64,7 +64,7 @@ ly_add_target(
             Gem::${gem_name}.Private.Object
             AZ::AzCore
             Gem::SimulationInterfaces.API
-            Gem::ROS2.Static
+            Gem::ROS2.API
 )
 
 # Include the gem name into the Client Module source file

--- a/sim/Gem/CMakeLists.txt
+++ b/sim/Gem/CMakeLists.txt
@@ -19,15 +19,6 @@ endif()
 # Note: We include the common files and the platform specific files which are set in mobilemanipulatordemo_files.cmake and
 # in ${pal_dir}/mobilemanipulatordemo_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
 
-find_package(simulation_interfaces REQUIRED)
-if(simulation_interfaces_VERSION VERSION_GREATER_EQUAL "2.0.0")
-  set(SIMULATION_INTERFACES_MAJOR_API_VERSION 2)
-elseif(simulation_interfaces_VERSION VERSION_GREATER_EQUAL "1.4.0")
-  set(SIMULATION_INTERFACES_MAJOR_API_VERSION 1)
-else()
-  message(FATAL_ERROR "simulation_interfaces version ${simulation_interfaces_VERSION} is not supported. Minimum required: 1.4.0")
-endif()
-message(STATUS "simulation_interfaces ${simulation_interfaces_VERSION} -> SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION}")
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this CMakeLists.txt
 ly_add_target(
@@ -46,9 +37,6 @@ ly_add_target(
             Gem::SimulationInterfaces.API
             Gem::ROS2.API
 )
-target_compile_definitions(${gem_name}.Private.Object PUBLIC
-    SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION})
-
 
 ly_add_target(
     NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}

--- a/sim/Gem/MobileManipulatorDemo_files.cmake
+++ b/sim/Gem/MobileManipulatorDemo_files.cmake
@@ -5,4 +5,9 @@ set(FILES
     Include/MobileManipulatorDemo/MobileManipulatorDemoBus.h
     Source/MobileManipulatorDemoSystemComponent.cpp
     Source/MobileManipulatorDemoSystemComponent.h
+
+    Source/SpawnEntityServiceHandler.cpp
+    Source/SpawnEntityServiceHandler.h
+    Source/SpawnServiceUtils.cpp
+    Source/SpawnServiceUtils.h
 )

--- a/sim/Gem/Source/MobileManipulatorDemoSystemComponent.cpp
+++ b/sim/Gem/Source/MobileManipulatorDemoSystemComponent.cpp
@@ -43,6 +43,17 @@ namespace MobileManipulatorDemo
     }
 
     MobileManipulatorDemoSystemComponent::MobileManipulatorDemoSystemComponent()
+        : m_nodeHandler([this] (std::shared_ptr<rclcpp::Node> node)
+            {
+                if (node)
+                {
+                    TryRegisterSpawnServiceHandler();
+                }
+                else
+                {
+                    DestroyHandlers();
+                }
+            })
     {
         if (MobileManipulatorDemoInterface::Get() == nullptr)
         {
@@ -62,28 +73,39 @@ namespace MobileManipulatorDemo
     {
     }
 
-    void MobileManipulatorDemoSystemComponent::Activate()
+    void MobileManipulatorDemoSystemComponent::TryRegisterSpawnServiceHandler()
     {
-        MobileManipulatorDemoRequestBus::Handler::BusConnect();
-
         auto ros2Node = ROS2::ROS2Interface::Get()->GetNode();
         if (!ros2Node)
         {
-            AZ_Trace("MobileManipulatorDemo", "ROS 2 node is not available.");
             return;
         }
 
         RegisterInterface<SpawnEntityServiceHandler>(ros2Node);
     }
 
-    void MobileManipulatorDemoSystemComponent::Deactivate()
+    void MobileManipulatorDemoSystemComponent::DestroyHandlers()
     {
-        MobileManipulatorDemoRequestBus::Handler::BusDisconnect();
-
         for (auto& [handlerType, handler] : m_availableRos2Interface)
         {
             handler.reset();
         }
         m_availableRos2Interface.clear();
+    }
+
+    void MobileManipulatorDemoSystemComponent::Activate()
+    {
+        MobileManipulatorDemoRequestBus::Handler::BusConnect();
+
+        ROS2::ROS2Interface::Get()->ConnectOnNodeChanged(m_nodeHandler);
+        TryRegisterSpawnServiceHandler();
+    }
+
+    void MobileManipulatorDemoSystemComponent::Deactivate()
+    {
+        MobileManipulatorDemoRequestBus::Handler::BusDisconnect();
+
+        m_nodeHandler.Disconnect();
+        DestroyHandlers();
     }
 }

--- a/sim/Gem/Source/MobileManipulatorDemoSystemComponent.cpp
+++ b/sim/Gem/Source/MobileManipulatorDemoSystemComponent.cpp
@@ -5,6 +5,9 @@
 
 #include <MobileManipulatorDemo/MobileManipulatorDemoTypeIds.h>
 
+#include <ROS2/ROS2Bus.h>
+#include "SpawnEntityServiceHandler.h"
+
 namespace MobileManipulatorDemo
 {
     AZ_COMPONENT_IMPL(MobileManipulatorDemoSystemComponent, "MobileManipulatorDemoSystemComponent",
@@ -32,6 +35,7 @@ namespace MobileManipulatorDemo
 
     void MobileManipulatorDemoSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
+        required.push_back(AZ_CRC_CE("ROS2Service"));
     }
 
     void MobileManipulatorDemoSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
@@ -61,10 +65,25 @@ namespace MobileManipulatorDemo
     void MobileManipulatorDemoSystemComponent::Activate()
     {
         MobileManipulatorDemoRequestBus::Handler::BusConnect();
+
+        auto ros2Node = ROS2::ROS2Interface::Get()->GetNode();
+        if (!ros2Node)
+        {
+            AZ_Trace("MobileManipulatorDemo", "ROS 2 node is not available.");
+            return;
+        }
+
+        RegisterInterface<SpawnEntityServiceHandler>(ros2Node);
     }
 
     void MobileManipulatorDemoSystemComponent::Deactivate()
     {
         MobileManipulatorDemoRequestBus::Handler::BusDisconnect();
+
+        for (auto& [handlerType, handler] : m_availableRos2Interface)
+        {
+            handler.reset();
+        }
+        m_availableRos2Interface.clear();
     }
 }

--- a/sim/Gem/Source/MobileManipulatorDemoSystemComponent.h
+++ b/sim/Gem/Source/MobileManipulatorDemoSystemComponent.h
@@ -5,8 +5,8 @@
 
 #include <MobileManipulatorDemo/MobileManipulatorDemoBus.h>
 
-#include "ROS2/Handlers/IROS2HandlerBase.h"
-#include "ROS2/ROS2Bus.h"
+#include <ROS2/Handlers/IROS2HandlerBase.h>
+#include <ROS2/ROS2Bus.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 
 namespace MobileManipulatorDemo

--- a/sim/Gem/Source/MobileManipulatorDemoSystemComponent.h
+++ b/sim/Gem/Source/MobileManipulatorDemoSystemComponent.h
@@ -5,6 +5,10 @@
 
 #include <MobileManipulatorDemo/MobileManipulatorDemoBus.h>
 
+#include "AzCore/Debug/Trace.h"
+#include "ROS2/Handlers/IROS2HandlerBase.h"
+#include <AzCore/std/smart_ptr/make_shared.h>
+
 namespace MobileManipulatorDemo
 {
     class MobileManipulatorDemoSystemComponent
@@ -36,5 +40,19 @@ namespace MobileManipulatorDemo
         void Activate() override;
         void Deactivate() override;
         ////////////////////////////////////////////////////////////////////////
+
+    private:
+        AZStd::unordered_map<AZStd::string, AZStd::shared_ptr<ROS2::IROS2HandlerBase>> m_availableRos2Interface;
+        template<typename T>
+        void RegisterInterface(rclcpp::Node::SharedPtr ros2Node)
+        {
+            AZStd::shared_ptr handler = AZStd::make_shared<T>();
+            handler->Initialize(ros2Node);
+            if (handler->IsValid())
+            {
+                m_availableRos2Interface[handler->GetTypeName()] = AZStd::move(handler);
+            }
+            handler.reset();
+        };
     };
 }

--- a/sim/Gem/Source/MobileManipulatorDemoSystemComponent.h
+++ b/sim/Gem/Source/MobileManipulatorDemoSystemComponent.h
@@ -5,8 +5,8 @@
 
 #include <MobileManipulatorDemo/MobileManipulatorDemoBus.h>
 
-#include "AzCore/Debug/Trace.h"
 #include "ROS2/Handlers/IROS2HandlerBase.h"
+#include "ROS2/ROS2Bus.h"
 #include <AzCore/std/smart_ptr/make_shared.h>
 
 namespace MobileManipulatorDemo
@@ -54,5 +54,9 @@ namespace MobileManipulatorDemo
             }
             handler.reset();
         };
+        ROS2::ROS2Requests::NodeChangedEvent::Handler m_nodeHandler;
+
+        void TryRegisterSpawnServiceHandler();
+        void DestroyHandlers();
     };
 }

--- a/sim/Gem/Source/ROS2Service.h
+++ b/sim/Gem/Source/ROS2Service.h
@@ -1,0 +1,77 @@
+// NOTE: This file is a slightly modified copy of ROS2/Code/Include/ROS2/Handlers/ROS2ServiceBase.h
+
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include <ROS2/Handlers/IROS2HandlerBase.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/optional.h>
+#include <rclcpp/service.hpp>
+
+namespace MobileManipulatorDemo
+{
+    template<typename RosServiceType>
+    class ROS2Service : public virtual ROS2::IROS2HandlerBase
+    {
+    public:
+        using Request = typename RosServiceType::Request;
+        using Response = typename RosServiceType::Response;
+        using ServiceHandle = std::shared_ptr<rclcpp::Service<RosServiceType>>;
+        virtual ~ROS2Service() = default;
+
+        void Initialize(rclcpp::Node::SharedPtr& node) override
+        {
+            CreateService(node);
+        }
+
+        void SendResponse(Response response)
+        {
+            AZ_Assert(m_serviceHandle, "Failed to get m_serviceHandle");
+            AZ_Assert(m_lastRequestHeader, "Failed to get last request header ptr");
+            m_serviceHandle->send_response(*m_lastRequestHeader, response);
+        }
+
+        bool IsValid() const override
+        {
+            return m_serviceHandle != nullptr;
+        }
+
+    protected:
+        //! This function is called when a service request is received.
+        virtual AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) = 0;
+
+    private:
+        void CreateService(rclcpp::Node::SharedPtr& node)
+        {
+            auto serviceName = GetDefaultName();
+            const std::string serviceNameStr(serviceName.data(), serviceName.size());
+            m_serviceHandle = node->create_service<RosServiceType>(
+                serviceNameStr,
+                [this](
+                    const ServiceHandle service_handle,
+                    const std::shared_ptr<rmw_request_id_t> header,
+                    const std::shared_ptr<Request> request)
+                {
+                    m_lastRequestHeader = header;
+                    auto response = HandleServiceRequest(header, *request);
+                    // if no response passed it means, that handleServiceRequest will send response in defined callback after time consuming
+                    // task, header needs to be cached
+                    if (response.has_value())
+                    {
+                        service_handle->send_response(*header, response.value());
+                    }
+                });
+        }
+
+        std::shared_ptr<rmw_request_id_t> m_lastRequestHeader = nullptr;
+        ServiceHandle m_serviceHandle;
+    };
+
+} // namespace MobileManipulatorDemo

--- a/sim/Gem/Source/SpawnEntityServiceHandler.cpp
+++ b/sim/Gem/Source/SpawnEntityServiceHandler.cpp
@@ -9,11 +9,10 @@
  */
 
 #include "SpawnEntityServiceHandler.h"
-#include "AzCore/Component/ComponentApplicationBus.h"
-#include "AzCore/Component/EntityId.h"
-#include "AzCore/Component/TransformBus.h"
-#include "AzCore/Debug/Trace.h"
-#include "SimulationInterfaces/Result.h"
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/Component/TransformBus.h>
+#include <SimulationInterfaces/Result.h>
 #include "SpawnServiceUtils.h"
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <ROS2/ROS2Bus.h>

--- a/sim/Gem/Source/SpawnEntityServiceHandler.cpp
+++ b/sim/Gem/Source/SpawnEntityServiceHandler.cpp
@@ -87,15 +87,21 @@ namespace MobileManipulatorDemo
                 simulation_interfaces::msg::SimulatorFeatures::SPAWNING });
     }
 
+    template<typename RequestT>
+    AZStd::string_view getSpawnRequestUri(const RequestT& request)
+    {
+        if constexpr (requires { RequestT::entity_resource; }) {
+            return { request.entity_resource.uri.c_str(), request.entity_resource.uri.size() };
+        } else {
+            return { request.uri.c_str(), request.uri.size() };
+        }
+    }
+
     AZStd::optional<SpawnEntityServiceHandler::Response> SpawnEntityServiceHandler::HandleServiceRequest(
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
         const AZStd::string_view name{ request.name.c_str(), request.name.size() };
-#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
-        const AZStd::string_view uri{ request.entity_resource.uri.c_str(), request.entity_resource.uri.size() };
-#else
-        const AZStd::string_view uri{ request.uri.c_str(), request.uri.size() };
-#endif
+        const AZStd::string_view uri = getSpawnRequestUri(request);
         const AZStd::string_view entityNamespace{ request.entity_namespace.c_str(), request.entity_namespace.size() };
         const AZStd::string_view messageFrameId{ request.initial_pose.header.frame_id.c_str(),
                                                  request.initial_pose.header.frame_id.size() };

--- a/sim/Gem/Source/SpawnEntityServiceHandler.cpp
+++ b/sim/Gem/Source/SpawnEntityServiceHandler.cpp
@@ -90,7 +90,6 @@ namespace MobileManipulatorDemo
     AZStd::optional<SpawnEntityServiceHandler::Response> SpawnEntityServiceHandler::HandleServiceRequest(
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
-        AZ_Printf("MobileManipulatorDemo", "Hello world!!! SpawnEntityServiceHandler");
         const AZStd::string_view name{ request.name.c_str(), request.name.size() };
 #if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
         const AZStd::string_view uri{ request.entity_resource.uri.c_str(), request.entity_resource.uri.size() };

--- a/sim/Gem/Source/SpawnEntityServiceHandler.cpp
+++ b/sim/Gem/Source/SpawnEntityServiceHandler.cpp
@@ -1,0 +1,203 @@
+// NOTE: this file is a slightly modified copy of SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnEntityServiceHandler.h"
+#include "AzCore/Component/ComponentApplicationBus.h"
+#include "AzCore/Component/EntityId.h"
+#include "AzCore/Component/TransformBus.h"
+#include "AzCore/Debug/Trace.h"
+#include "SimulationInterfaces/Result.h"
+#include "SpawnServiceUtils.h"
+#include <AzFramework/Physics/ShapeConfiguration.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/TF/TransformInterface.h>
+#include <ROS2/Utilities/ROS2Conversions.h>
+#include <SimulationInterfaces/RegistryUtils.h>
+#include <SimulationInterfaces/SimulationEntityManagerRequestBus.h>
+#include <SimulationInterfaces/ROS2SimulationInterfacesRequestBus.h>
+#include <simulation_interfaces/msg/simulator_features.hpp>
+
+namespace MobileManipulatorDemo
+{
+    AZStd::vector<AZ::EntityId> GetAllDescendants(AZ::EntityId parent)
+    {
+        AZStd::vector<AZ::EntityId> descendants;
+        AZ::TransformBus::EventResult(
+            descendants,
+            parent,
+            &AZ::TransformInterface::GetAllDescendants);
+
+        return descendants;
+    }
+
+    AZStd::string GetEntityName(AZ::EntityId entityId)
+    {
+        AZStd::string name;
+        AZ::ComponentApplicationBus::BroadcastResult(
+            name,
+            &AZ::ComponentApplicationRequests::GetEntityName,
+            entityId
+        );
+
+        return name;
+    }
+
+    void RegisterChildGrippingPoints(const AZStd::string& rootName)
+    {
+        AZ::Outcome<AZ::EntityId, SimulationInterfaces::FailedResult> rootId;
+        SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
+            rootId,
+            &SimulationInterfaces::SimulationEntityManagerRequests::GetEntityRoot,
+            rootName
+        );
+
+        if (rootId.IsSuccess())
+        {
+            for (auto& descendantId : GetAllDescendants(rootId.GetValue()))
+            {
+                auto descendantName = GetEntityName(descendantId);
+
+                if (descendantName.contains("GrippingPoint"))
+                {
+                    auto proposedName = rootName + "_" + descendantName;
+                    AZ::Outcome<AZStd::string, SimulationInterfaces::FailedResult> result;
+                    SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
+                        result,
+                        &SimulationInterfaces::SimulationEntityManagerRequests::RegisterNewSimulatedBody,
+                        proposedName,
+                        descendantId
+                    );
+                }
+            }
+        }
+    }
+
+    SpawnEntityServiceHandler::SpawnEntityServiceHandler()
+    {
+        ROS2SimulationInterfaces::ROS2SimulationInterfacesRequestBus::Broadcast(
+            &ROS2SimulationInterfaces::ROS2SimulationInterfacesRequests::AddSimulationFeatures,
+            AZStd::unordered_set<ROS2SimulationInterfaces::SimulationFeatureType>{
+                simulation_interfaces::msg::SimulatorFeatures::SPAWNING });
+    }
+
+    AZStd::optional<SpawnEntityServiceHandler::Response> SpawnEntityServiceHandler::HandleServiceRequest(
+        const std::shared_ptr<rmw_request_id_t> header, const Request& request)
+    {
+        AZ_Printf("MobileManipulatorDemo", "Hello world!!! SpawnEntityServiceHandler");
+        const AZStd::string_view name{ request.name.c_str(), request.name.size() };
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+        const AZStd::string_view uri{ request.entity_resource.uri.c_str(), request.entity_resource.uri.size() };
+#else
+        const AZStd::string_view uri{ request.uri.c_str(), request.uri.size() };
+#endif
+        const AZStd::string_view entityNamespace{ request.entity_namespace.c_str(), request.entity_namespace.size() };
+        const AZStd::string_view messageFrameId{ request.initial_pose.header.frame_id.c_str(),
+                                                 request.initial_pose.header.frame_id.size() };
+        const builtin_interfaces::msg::Time zeroTime = builtin_interfaces::msg::Time();
+
+        // Validate entity name
+        if (!name.empty() && !SpawnServiceUtils::ValidateEntityName(name))
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAME_INVALID;
+            response.result.error_message = "Invalid entity name. Entity names can only contain alphanumeric characters and underscores.";
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        // Validate namespace name
+        if (!entityNamespace.empty() && !SpawnServiceUtils::ValidateNamespaceName(entityNamespace))
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAMESPACE_INVALID;
+            response.result.error_message =
+                "Invalid entity namespace. Entity namespaces can only contain alphanumeric characters and forward slashes.";
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        // deal with frames
+        const auto simulatorFrameId = ROS2SimulationInterfaces::RegistryUtilities::GetSimulatorROS2Frame();
+        AZ::Transform transformOffset = AZ::Transform::CreateIdentity();
+        if (!messageFrameId.empty() && simulatorFrameId != messageFrameId)
+        {
+            auto transformInterface = ROS2::TFInterface::Get();
+            AZ_Assert(transformInterface, "TFInterface is not available, cannot set entity state without transform offset.");
+            const auto transformOutcome = transformInterface->GetTransform(simulatorFrameId, messageFrameId, zeroTime);
+
+            if (transformOutcome.IsSuccess())
+            {
+                transformOffset = transformOutcome.GetValue();
+            }
+            else
+            {
+                Response response;
+                response.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
+                response.result.error_message = transformOutcome.GetError().c_str();
+                SendResponse(response);
+                return AZStd::nullopt;
+            }
+        }
+
+        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
+        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE;
+            response.result.error_message = poseValidation.GetError().c_str();
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        const AZ::Transform initialPose = transformOffset *
+            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
+        SimulationInterfaces::PreInsertionCb preinsertionCB =
+            [this](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>& outcome)
+        {
+            if (!outcome.IsSuccess())
+            {
+                Response response;
+                const auto& failedResult = outcome.GetError();
+                response.result.result = failedResult.m_errorCode;
+                response.result.error_message = failedResult.m_errorString.c_str();
+
+                SendResponse(response);
+            }
+        };
+        SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
+            &SimulationInterfaces::SimulationEntityManagerRequests::SpawnEntity,
+            name,
+            uri,
+            entityNamespace,
+            initialPose,
+            request.allow_renaming,
+            preinsertionCB,
+            [this](const AZ::Outcome<AZStd::string, SimulationInterfaces::FailedResult>& outcome)
+            {
+                Response response;
+                if (outcome.IsSuccess())
+                {
+                    RegisterChildGrippingPoints(outcome.GetValue());
+                    response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
+                    response.entity_name = outcome.GetValue().c_str();
+                }
+                else
+                {
+                    const auto& failedResult = outcome.GetError();
+                    response.result.result = failedResult.m_errorCode;
+                    response.result.error_message = failedResult.m_errorString.c_str();
+                }
+                SendResponse(response);
+            });
+        return AZStd::nullopt;
+    }
+
+} // namespace MobileManipulatorDemo

--- a/sim/Gem/Source/SpawnEntityServiceHandler.h
+++ b/sim/Gem/Source/SpawnEntityServiceHandler.h
@@ -1,0 +1,37 @@
+// NOTE: this file is a slightly modified copy of SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "ROS2Service.h"
+#include <AzCore/std/string/string_view.h>
+#include <simulation_interfaces/srv/spawn_entity.hpp>
+
+namespace MobileManipulatorDemo
+{
+    class SpawnEntityServiceHandler
+        : public ROS2Service<simulation_interfaces::srv::SpawnEntity>
+    {
+    public:
+        SpawnEntityServiceHandler();
+
+        AZStd::string_view GetTypeName() const override
+        {
+            return "SpawnEntity";
+        }
+
+        AZStd::string_view GetDefaultName() const override
+        {
+            return "spawn_entity";
+        }
+
+        AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
+    };
+} // namespace MobileManipulatorDemo

--- a/sim/Gem/Source/SpawnServiceUtils.cpp
+++ b/sim/Gem/Source/SpawnServiceUtils.cpp
@@ -1,0 +1,57 @@
+// NOTE: this file is a slightly modified copy of SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.cpp
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnServiceUtils.h"
+#include <AzCore/std/string/regex.h>
+#include <AzCore/std/string/string.h>
+
+namespace MobileManipulatorDemo::SpawnServiceUtils
+{
+    bool ValidateEntityName(AZStd::string_view entityName)
+    {
+        static const AZStd::regex entityRegex{
+            R"(^[a-zA-Z0-9_]+$)"
+        }; // Entity names can only contain alphanumeric characters and underscores
+        return AZStd::regex_match(entityName.begin(), entityName.end(), entityRegex);
+    }
+
+    bool ValidateNamespaceName(AZStd::string_view namespaceName)
+    {
+        static const AZStd::regex namespaceRegex{
+            R"(^[a-zA-Z0-9_/]+$)"
+        }; // Namespace names can only contain alphanumeric characters and forward slashes
+        return AZStd::regex_match(namespaceName.begin(), namespaceName.end(), namespaceRegex);
+    }
+
+    AZ::Outcome<void, AZStd::string> ValidateTransformNormalized(
+        const AZ::Transform& transform, float quaternionTolerance, float maxTranslation)
+    {
+        // Check rotation quaternion is normalised.
+        const float quaternionLength = transform.GetRotation().GetLength();
+        if (!AZ::IsClose(quaternionLength, 1.0f, quaternionTolerance))
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose orientation quaternion: length is not close to 1.0.");
+        }
+
+        // Check translation components are finite and within range.
+        const AZ::Vector3 translation = transform.GetTranslation();
+        if (!translation.IsFinite())
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose translation: one or more components are NaN or infinite.");
+        }
+        const float absMax = translation.GetAbs().GetMaxElement();
+        if (absMax > maxTranslation)
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose translation: exceeds the maximum allowed.");
+        }
+
+        return AZ::Success();
+    }
+} // namespace MobileManipulatorDemo::SpawnServiceUtils

--- a/sim/Gem/Source/SpawnServiceUtils.h
+++ b/sim/Gem/Source/SpawnServiceUtils.h
@@ -1,0 +1,30 @@
+// NOTE: this file is a slightly modified copy of SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.h
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+
+namespace MobileManipulatorDemo::SpawnServiceUtils
+{
+    bool ValidateEntityName(AZStd::string_view entityName);
+    bool ValidateNamespaceName(AZStd::string_view namespaceName);
+
+    //! Validates that the transform has a normalised rotation quaternion and a finite, in-range translation.
+    //! @param transform     Transform to validate.
+    //! @param quaternionTolerance  Tolerance on |quaternion| - 1.0f. Defaults to 1e-3f.
+    //! @param maxTranslation Maximum allowed absolute value per axis in metres. Defaults to 1e7f (~10 000 km).
+    //! @return Success when valid, Failure with a descriptive error message when not.
+    AZ::Outcome<void, AZStd::string> ValidateTransformNormalized(
+        const AZ::Transform& transform, float quaternionTolerance = 1e-3f, float maxTranslation = 1e7f);
+} // namespace MobileManipulatorDemo::SpawnServiceUtils

--- a/sim/Gem/gem.json
+++ b/sim/Gem/gem.json
@@ -2,12 +2,12 @@
     "gem_name": "MobileManipulatorDemo",
     "version": "1.0.0",
     "display_name": "MobileManipulatorDemo",
-    "license": "What license MobileManipulatorDemo uses goes here: i.e. Apache-2.0 or MIT",
-    "license_url": "Link to the license web site goes here: i.e. https://opensource.org/licenses/Apache-2.0 Or https://opensource.org/licenses/MIT",
-    "origin": "The name of the originator goes here. i.e. XYZ Inc.",
-    "origin_url": "The primary repo for MobileManipulatorDemo goes here: i.e. http://www.mydomain.com",
+    "license": "Apache-2.0",
+    "license_url": "https://opensource.org/licenses/Apache-2.0",
+    "origin": "https://github.com/RobotecAI/MobileManipulatorDemo",
+    "origin_url": "https://github.com/RobotecAI/MobileManipulatorDemo",
     "type": "",
-    "summary": "A short description of MobileManipulatorDemo.",
+    "summary": "Simulation environment for the Mobile Manipulator Demo.",
     "canonical_tags": [
         "Gem"
     ],

--- a/sim/Gem/gem.json
+++ b/sim/Gem/gem.json
@@ -1,29 +1,20 @@
 {
-    "gem_name": "MobileManipulatorDemo",
-    "version": "1.0.0",
-    "display_name": "MobileManipulatorDemo",
-    "license": "What license MobileManipulatorDemo uses goes here: i.e. Apache-2.0 or MIT",
-    "license_url": "Link to the license web site goes here: i.e. https://opensource.org/licenses/Apache-2.0 Or https://opensource.org/licenses/MIT",
-    "origin": "The name of the originator goes here. i.e. XYZ Inc.",
-    "origin_url": "The primary repo for MobileManipulatorDemo goes here: i.e. http://www.mydomain.com",
-    "type": "",
-    "summary": "A short description of MobileManipulatorDemo.",
-    "canonical_tags": [
-        "Gem"
-    ],
-    "user_tags": [
-        "MobileManipulatorDemo"
-    ],
-    "platforms": [
-        "${Platforms}"
-    ],
-    "icon_path": "preview.png",
-    "requirements": "",
-    "documentation_url": "",
-    "dependencies": [
-    ],
-    "compatible_engines": [
-    ],
-    "engine_api_dependencies":[
-    ]
+  "gem_name": "MobileManipulatorDemo",
+  "version": "1.0.0",
+  "display_name": "MobileManipulatorDemo",
+  "license": "What license MobileManipulatorDemo uses goes here: i.e. Apache-2.0 or MIT",
+  "license_url": "Link to the license web site goes here: i.e. https://opensource.org/licenses/Apache-2.0 Or https://opensource.org/licenses/MIT",
+  "origin": "The name of the originator goes here. i.e. XYZ Inc.",
+  "origin_url": "The primary repo for MobileManipulatorDemo goes here: i.e. http://www.mydomain.com",
+  "type": "",
+  "summary": "A short description of MobileManipulatorDemo.",
+  "canonical_tags": ["Gem"],
+  "user_tags": ["MobileManipulatorDemo"],
+  "platforms": ["${Platforms}"],
+  "icon_path": "preview.png",
+  "requirements": "",
+  "documentation_url": "",
+  "dependencies": ["SimulationInterfaces", "ROS2>=4.1.0"],
+  "compatible_engines": [],
+  "engine_api_dependencies": []
 }

--- a/sim/Gem/gem.json
+++ b/sim/Gem/gem.json
@@ -1,20 +1,31 @@
 {
-  "gem_name": "MobileManipulatorDemo",
-  "version": "1.0.0",
-  "display_name": "MobileManipulatorDemo",
-  "license": "What license MobileManipulatorDemo uses goes here: i.e. Apache-2.0 or MIT",
-  "license_url": "Link to the license web site goes here: i.e. https://opensource.org/licenses/Apache-2.0 Or https://opensource.org/licenses/MIT",
-  "origin": "The name of the originator goes here. i.e. XYZ Inc.",
-  "origin_url": "The primary repo for MobileManipulatorDemo goes here: i.e. http://www.mydomain.com",
-  "type": "",
-  "summary": "A short description of MobileManipulatorDemo.",
-  "canonical_tags": ["Gem"],
-  "user_tags": ["MobileManipulatorDemo"],
-  "platforms": ["${Platforms}"],
-  "icon_path": "preview.png",
-  "requirements": "",
-  "documentation_url": "",
-  "dependencies": ["SimulationInterfaces", "ROS2>=4.1.0"],
-  "compatible_engines": [],
-  "engine_api_dependencies": []
+    "gem_name": "MobileManipulatorDemo",
+    "version": "1.0.0",
+    "display_name": "MobileManipulatorDemo",
+    "license": "What license MobileManipulatorDemo uses goes here: i.e. Apache-2.0 or MIT",
+    "license_url": "Link to the license web site goes here: i.e. https://opensource.org/licenses/Apache-2.0 Or https://opensource.org/licenses/MIT",
+    "origin": "The name of the originator goes here. i.e. XYZ Inc.",
+    "origin_url": "The primary repo for MobileManipulatorDemo goes here: i.e. http://www.mydomain.com",
+    "type": "",
+    "summary": "A short description of MobileManipulatorDemo.",
+    "canonical_tags": [
+        "Gem"
+    ],
+    "user_tags": [
+        "MobileManipulatorDemo"
+    ],
+    "platforms": [
+        "${Platforms}"
+    ],
+    "icon_path": "preview.png",
+    "requirements": "",
+    "documentation_url": "",
+    "dependencies": [
+      "SimulationInterfaces",
+      "ROS2>=4.1.0"
+    ],
+    "compatible_engines": [
+    ],
+    "engine_api_dependencies":[
+    ]
 }

--- a/sim/Gem/mobilemanipulatordemo_files.cmake
+++ b/sim/Gem/mobilemanipulatordemo_files.cmake
@@ -4,4 +4,9 @@ set(FILES
     Include/MobileManipulatorDemo/MobileManipulatorDemoTypeIds.h
     Source/MobileManipulatorDemoSystemComponent.cpp
     Source/MobileManipulatorDemoSystemComponent.h
+
+    Source/SpawnEntityServiceHandler.cpp
+    Source/SpawnEntityServiceHandler.h
+    Source/SpawnServiceUtils.cpp
+    Source/SpawnServiceUtils.h
 )

--- a/sim/Registry/ros2.setreg
+++ b/sim/Registry/ros2.setreg
@@ -21,6 +21,10 @@
             "Camera":
             {
                 "AllowPipelineModification": true
+            },
+            "HandlersNames":
+            {
+                "SpawnEntity": ""
             }
         }
     }

--- a/sim/project.json
+++ b/sim/project.json
@@ -13,16 +13,9 @@
         "MobileManipulatorDemo"
     ],
     "icon_path": "preview.png",
-    "engine": "o3de",
+    "engine": "o3de-sdk",
     "external_subdirectories": [
         "Gem",
-        "../gems/o3de-extras/Gems/LevelGeoreferencing",
-        "../gems/o3de-extras/Gems/ROS2",
-        "../gems/o3de-extras/Gems/ROS2Controllers",
-        "../gems/o3de-extras/Gems/ROS2SampleRobots",
-        "../gems/o3de-extras/Gems/ROS2Sensors",
-        "../gems/o3de-extras/Gems/SimulationInterfaces",
-        "../gems/o3de-extras/Gems/WarehouseAssets",
         "../gems/o3de-humanworker-gem",
         "../gems/o3de-ur-robots-gem",
         "../gems/robotec-o3de-tools/Gems/RobotecSpectatorCamera",

--- a/sim/project.json
+++ b/sim/project.json
@@ -91,5 +91,5 @@
         "RobotecWarehouseFloorMarkingAssets",
         "HumanWorker"
     ],
-    "engine_version": "2.4.0"
+    "engine_version": "2.6.0"
 }


### PR DESCRIPTION
This PR updates the project to o3de 2605 and switches to o3de SDK installed from .deb instead of building o3de from source.

In o3de 2605 the spawn entity service implementation changed such that only the top level physical entity is tracked after spawning. In the demo we want to track the gripping points of the spawned boxes, so a custom spawn service handler is implemented in this PR that registers the gripping points for tracking, while the default handler is disabled, effectively replacing it without changing the name and type of the service.