### PR TITLE
feat: npu workflow

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -206,6 +206,10 @@ description = "Serve Qwen3-Reranker-0.6B on port 8083"
 cmd = "bash scripts/serve_all.sh"
 description = "Launch all inference servers in a tmux session (2x2 grid)"
 
+[feature.local-inference.tasks.install-npu-inference]
+cmd = "bash scripts/install_npu_inference.sh"
+description = "Install AMD NPU drivers + FastFlowLM for NPU inference (optional; may require reboot)"
+
 # ─── Profile features ───────────────────────────────────────────────────────────
 # One profile feature per environment. Each defines a `setup` entry point so
 # that `pixi run -e <env> setup` builds exactly the components for that machine.

--- a/scripts/install_npu_inference.sh
+++ b/scripts/install_npu_inference.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Install AMD Ryzen AI NPU drivers + FastFlowLM for NPU inference.
+# Idempotent — skips drivers/packages that are already installed.
+
+set -euo pipefail
+
+FFLM_REPO="${FFLM_REPO:-https://github.com/RobotecAI/FastFlowLM.git}"
+PROJECT_ROOT="${PIXI_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+FFLM_SRC="${FFLM_SRC:-$PROJECT_ROOT/inference/FastFlowLM}"
+
+SUDO=""
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    SUDO="sudo"
+fi
+
+REBOOT_NEEDED=0
+
+# ── Step 1: NPU drivers (libxrt-npu2, amdxdna-dkms) ─────────────────────────
+if dpkg -s libxrt-npu2 amdxdna-dkms >/dev/null 2>&1; then
+    echo "NPU drivers already installed, skipping."
+else
+    $SUDO add-apt-repository -y ppa:lemonade-team/stable
+    $SUDO apt update
+    $SUDO apt install -y libxrt-npu2 amdxdna-dkms
+    REBOOT_NEEDED=1
+    echo ">>> NPU drivers installed. A REBOOT is required before they take effect."
+fi
+
+# ── Step 2: FastFlowLM (build from source) ──────────────────────────────────
+if command -v flm >/dev/null 2>&1; then
+    echo "flm already installed, skipping build."
+else
+    $SUDO apt install -y ninja-build \
+        libavformat-dev libavutil-dev libavcodec-dev libswresample-dev \
+        libswscale-dev libxrt-dev uuid-dev libdrm-dev
+
+    if [[ ! -d "$FFLM_SRC/.git" ]]; then
+        git clone --recursive "$FFLM_REPO" "$FFLM_SRC"
+    fi
+
+    cd "$FFLM_SRC/src"
+    cmake --preset linux-default
+    cd build
+    cmake --build . -j"$(nproc)"
+    $SUDO cmake --install .
+    cd "$PROJECT_ROOT"
+fi
+
+# ── Step 3: memlock limit ───────────────────────────────────────────────────
+# NPU inference needs unlimited locked memory.
+memlock="$(ulimit -l)"
+if [[ "$memlock" != "unlimited" ]]; then
+    limits="/etc/security/limits.conf"
+    if ! grep -qE '^\*[[:space:]]+(soft|hard)[[:space:]]+memlock[[:space:]]+unlimited' "$limits"; then
+        echo "*    soft    memlock    unlimited" | $SUDO tee -a "$limits" >/dev/null
+        echo "*    hard    memlock    unlimited" | $SUDO tee -a "$limits" >/dev/null
+        echo ">>> Added memlock=unlimited to $limits."
+    fi
+    REBOOT_NEEDED=1
+    echo ">>> memlock limit is '$memlock' (need 'unlimited'). A REBOOT is required."
+fi
+
+if [[ "$REBOOT_NEEDED" -eq 1 ]]; then
+    echo
+    echo "============================================================"
+    echo " Setup incomplete: please REBOOT, then re-run to verify."
+    echo "============================================================"
+    exit 0
+fi
+
+# ── Step 4: validate (only meaningful once drivers are active) ───────────────
+# Diagnostics only — don't abort if no NPU device is present yet.
+# Capture output; only show it on failure, otherwise a clean status line.
+xrt_out="$(xrt-smi examine 2>&1)"; xrt_rc=$?
+flm_out="$(flm validate 2>&1)"; flm_rc=$?
+
+if [[ "$xrt_rc" -eq 0 && "$flm_rc" -eq 0 ]]; then
+    printf '\033[32m✓ NPU visible & ready\033[0m\n'
+    printf '\033[32m✓ FLM ready\033[0m\n'
+else
+    echo "$xrt_out"
+    echo "$flm_out"
+    cat <<'EOF'
+
+============================================================
+ No NPU device found. Troubleshooting:
+
+ 1. Is the amdxdna kernel module loaded?
+      lsmod | grep amdxdna
+    If not:  sudo modprobe amdxdna
+    Persist: echo amdxdna | sudo tee /etc/modules-load.d/amdxdna.conf
+
+ 2. Does xrt-smi see the device? (look for RyzenAI-npu under
+    "Device(s) Present" in the output above)
+      xrt-smi examine
+
+ More:
+   https://github.com/FastFlowLM/FastFlowLM/blob/main/docs/linux-getting-started.md
+   https://lemonade-server.ai/flm_npu_linux.html
+============================================================
+EOF
+fi


### PR DESCRIPTION
# feat: NPU inference setup (FastFlowLM + AMD Ryzen AI)

Adds an optional, one-command setup for running LLM inference on the AMD Ryzen AI NPU via [FastFlowLM](https://github.com/FastFlowLM/FastFlowLM), targeting the Ryzen AI MAX+ 395 (Strix Halo) machines.

## What's in this PR

- **`pixi run -e local install-npu-inference`** — new optional task under the `local-inference` feature (`pixi.toml`).
- **`scripts/install_npu_inference.sh`** — idempotent installer that:
  1. **NPU drivers** — adds the `lemonade-team/stable` PPA and installs `libxrt-npu2` + `amdxdna-dkms`; skips if already present, flags reboot when freshly installed.
  2. **FastFlowLM (from source)** — installs build deps (ninja, ffmpeg libs, libxrt-dev, etc.), clones `RobotecAI/FastFlowLM` into `inference/FastFlowLM/`, builds with the `linux-default` CMake preset, and `sudo cmake --install`s `flm`. Skips if `flm` is already on PATH.
  3. **memlock limit** — checks `ulimit -l`; appends `* soft/hard memlock unlimited` to `/etc/security/limits.conf` if not already unlimited, and flags reboot.
  4. **Validate** — runs `xrt-smi examine` + `flm validate`, capturing output. On success prints a clean `✓ NPU visible & ready / ✓ FLM ready`; on failure prints the captured diagnostics plus a troubleshooting block (kernel module loaded? `xrt-smi` seeing the device?) with links to the FastFlowLM and Lemonade Linux guides.

## Tested on

AMD Ryzen AI MAX+ 395, Ubuntu 24.04, kernel 6.17.0-1025-oem.

## TODO

- [ ] Wire FastFlowLM into the actual AI stack (RAI) — add an `flm serve` task analogous to the `serve-llm` / `serve-vlm` llama.cpp tasks, exposing an OpenAI-compatible endpoint.
- [ ] Point the agents/orchestrator config at the NPU endpoint and run an end-to-end demo on NPU inference.
- [ ] Pick + document the model(s) served on the NPU (and download path).
- [ ] Decide whether to fold `modprobe` persistence + IOMMU check into the script or keep them as manual/documented steps.
- [ ] Document `install-npu-inference` in the setup docs (`docs/setup_*.md`).
