### PR TITLE
fix: pixi test command

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -357,7 +357,7 @@ depends-on = ["sync"]
 description = "Run all linters and formatters"
 
 [feature.dev.tasks.test]
-cmd = "uv run pytest"
+cmd = "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run python -m pytest"
 depends-on = ["sync"]
 description = "Run test suite"
 


### PR DESCRIPTION
This PR fixes an error caused by some pytest plugins from ROS2 being built for a different pytest version than ours:
```
.pixi/envs/default/lib/python3.12/site-packages/pluggy/_manager.py", line 343, in _verify_hook
    raise PluginValidationError(
pluggy._manager.PluginValidationError: Plugin 'launch_testing' for hook 'pytest_pycollect_makemodule'
hookimpl definition: pytest_pycollect_makemodule(path, parent)
Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
```