### PR TITLE
fix: catch llm exceptions in ros2 agents

### DIFF
--- a/rai_app/agents/moveit2_agent.py
+++ b/rai_app/agents/moveit2_agent.py
@@ -468,11 +468,14 @@ class MoveIt2Agent(BaseAgent):
                 )
             except Exception as e:
                 response.success = False
-                llm_response = self.llm.invoke(
-                    "The arm failed to move to the position. Check the logs and provide a short summary."
-                    + str(e)
-                )
-                response.report = llm_response.content
+                try:
+                    llm_response = self.llm.invoke(
+                        "The arm failed to move to the position. Check the logs and provide a short summary."
+                        + str(e)
+                    )
+                    response.report = llm_response.content
+                except Exception:
+                    response.report = f"The arm failed to move to the position: {e}"
                 return response
 
         if request.gripper_state == 0:
@@ -486,10 +489,13 @@ class MoveIt2Agent(BaseAgent):
             except Exception as e:
                 self.logger.error(f"Failed to open gripper: {e}")
                 response.success = False
-                llm_response = self.llm.invoke(
-                    self.formulate_prompt("The arm failed to open the gripper.", str(e))
-                )
-                response.report = llm_response.content
+                try:
+                    llm_response = self.llm.invoke(
+                        self.formulate_prompt("The arm failed to open the gripper.", str(e))
+                    )
+                    response.report = llm_response.content
+                except Exception:
+                    response.report = f"The arm failed to open the gripper: {e}"
                 return response
         elif request.gripper_state == 2:
             try:
@@ -499,12 +505,15 @@ class MoveIt2Agent(BaseAgent):
             except Exception as e:
                 self.logger.error(f"Failed to close gripper: {e}")
                 response.success = False
-                llm_response = self.llm.invoke(
-                    self.formulate_prompt(
-                        "The arm failed to close the gripper.", str(e)
+                try:
+                    llm_response = self.llm.invoke(
+                        self.formulate_prompt(
+                            "The arm failed to close the gripper.", str(e)
+                        )
                     )
-                )
-                response.report = llm_response.content
+                    response.report = llm_response.content
+                except Exception:
+                    response.report = f"The arm failed to open the gripper: {e}"
                 return response
         else:
             response.success = False

--- a/rai_app/agents/moveit2_agent.py
+++ b/rai_app/agents/moveit2_agent.py
@@ -491,7 +491,9 @@ class MoveIt2Agent(BaseAgent):
                 response.success = False
                 try:
                     llm_response = self.llm.invoke(
-                        self.formulate_prompt("The arm failed to open the gripper.", str(e))
+                        self.formulate_prompt(
+                            "The arm failed to open the gripper.", str(e)
+                        )
                     )
                     response.report = llm_response.content
                 except Exception:

--- a/rai_app/agents/moveit2_agent.py
+++ b/rai_app/agents/moveit2_agent.py
@@ -470,8 +470,10 @@ class MoveIt2Agent(BaseAgent):
                 response.success = False
                 try:
                     llm_response = self.llm.invoke(
-                        "The arm failed to move to the position. Check the logs and provide a short summary."
-                        + str(e)
+                        self.formulate_prompt(
+                            "The arm failed to move to the position. Check the logs and provide a short summary.",
+                            str(e),
+                        )
                     )
                     response.report = llm_response.content
                 except Exception:

--- a/rai_app/agents/nav2_agent.py
+++ b/rai_app/agents/nav2_agent.py
@@ -158,15 +158,18 @@ class Nav2Agent(BaseAgent):
         elif result == TaskResult.FAILED:
             reason = self.navigator.result_future.result().result.error_code
             enum_name = decode_error_code(reason, Nav2NavigateToPose)
-            response = self.llm.invoke(
-                self.formulate_prompt(
-                    f"Navigate to pose has failed with error code {enum_name}. Check the logs and provide a short summary.",
-                    str(feedback),
-                    request.pose,
-                )
-            )
             action_result.success = False
-            action_result.report = response.content
+            try:
+                response = self.llm.invoke(
+                    self.formulate_prompt(
+                        f"Navigate to pose has failed with error code {enum_name}. Check the logs and provide a short summary.",
+                        str(feedback),
+                        request.pose,
+                    )
+                )
+                action_result.report = response.content
+            except Exception:
+                action_result.report = f"Navigate to pose has failed with error code {enum_name}"
             return action_result
         else:
             action_result.success = False
@@ -213,15 +216,18 @@ class Nav2Agent(BaseAgent):
             goal_handle.abort()
             reason = self.navigator.result_future.result().result.error_code
             enum_name = decode_error_code(reason, Nav2DriveOnHeading)
-            response = self.llm.invoke(
-                self.formulate_prompt(
-                    f"Drive on heading has failed with error code {enum_name}. Check the logs and provide a short summary.",
-                    str(feedback),
-                    params,
-                )
-            )
             action_result.success = False
-            action_result.report = response.content
+            try:
+                response = self.llm.invoke(
+                    self.formulate_prompt(
+                        f"Drive on heading has failed with error code {enum_name}. Check the logs and provide a short summary.",
+                        str(feedback),
+                        params,
+                    )
+                )
+                action_result.report = response.content
+            except Exception:
+                action_result.report = f"Drive on heading has failed with error code {enum_name}"
             return action_result
         else:
             action_result.success = False
@@ -273,15 +279,18 @@ class Nav2Agent(BaseAgent):
             enum_name = decode_error_code(reason, Nav2Spin)
 
             goal_handle.abort()
-            response = self.llm.invoke(
-                self.formulate_prompt(
-                    f"Turn (requested angle: {request.target_yaw} radians) has failed with error code {enum_name}. Check the logs and provide a short summary.",
-                    str(feedback),
-                    params,
-                )
-            )
             action_result.success = False
-            action_result.report = response.content
+            try:
+                response = self.llm.invoke(
+                    self.formulate_prompt(
+                        f"Turn (requested angle: {request.target_yaw} radians) has failed with error code {enum_name}. Check the logs and provide a short summary.",
+                        str(feedback),
+                        params,
+                    )
+                )
+                action_result.report = response.content
+            except Exception:
+                action_result.report = f"Turn (requested angle: {request.target_yaw} radians) has failed with error code {enum_name}."
             return action_result
         else:
             action_result.success = False
@@ -317,15 +326,18 @@ class Nav2Agent(BaseAgent):
             enum_name = decode_error_code(reason, Nav2Spin)
 
             goal_handle.abort()
-            response = self.llm.invoke(
-                self.formulate_prompt(
-                    f"Followed waypoints has failed with error code {enum_name}. Check the logs and provide a short summary.",
-                    str(feedback),
-                    request.poses,
-                )
-            )
             action_result.success = False
-            action_result.report = response.content
+            try:
+                response = self.llm.invoke(
+                    self.formulate_prompt(
+                        f"Followed waypoints has failed with error code {enum_name}. Check the logs and provide a short summary.",
+                        str(feedback),
+                        request.poses,
+                    )
+                )
+                action_result.report = response.content
+            except Exception:
+                action_result.report = f"Followed waypoints has failed with error code {enum_name}."
             return action_result
         else:
             action_result.success = False

--- a/rai_app/agents/nav2_agent.py
+++ b/rai_app/agents/nav2_agent.py
@@ -169,7 +169,9 @@ class Nav2Agent(BaseAgent):
                 )
                 action_result.report = response.content
             except Exception:
-                action_result.report = f"Navigate to pose has failed with error code {enum_name}"
+                action_result.report = (
+                    f"Navigate to pose has failed with error code {enum_name}"
+                )
             return action_result
         else:
             action_result.success = False
@@ -227,7 +229,9 @@ class Nav2Agent(BaseAgent):
                 )
                 action_result.report = response.content
             except Exception:
-                action_result.report = f"Drive on heading has failed with error code {enum_name}"
+                action_result.report = (
+                    f"Drive on heading has failed with error code {enum_name}"
+                )
             return action_result
         else:
             action_result.success = False
@@ -337,7 +341,9 @@ class Nav2Agent(BaseAgent):
                 )
                 action_result.report = response.content
             except Exception:
-                action_result.report = f"Followed waypoints has failed with error code {enum_name}."
+                action_result.report = (
+                    f"Followed waypoints has failed with error code {enum_name}."
+                )
             return action_result
         else:
             action_result.success = False


### PR DESCRIPTION
When a moveit2 or nav2 tool fails, and the llm call also fails, then the exception is unhandled and the tool service does not respond. This PR catches those exceptions and makes the tool respond with the raw error code.