### PR TITLE
fix: housekeep tool and tests

### DIFF
--- a/rai_app/agents/tools.py
+++ b/rai_app/agents/tools.py
@@ -887,6 +887,8 @@ class HouseKeepTool(WarehouseTool):
                     pos, collection_name=rack, approach_distance=self.approach_distance
                 )
             except RuntimeError as e:
+                if "arm" in str(e): # don't count moveit related exceptions as "side not available"
+                    raise e
                 sides_not_available += 1
                 logging.warning(e)
             except Exception as e:

--- a/rai_app/agents/tools.py
+++ b/rai_app/agents/tools.py
@@ -887,7 +887,9 @@ class HouseKeepTool(WarehouseTool):
                     pos, collection_name=rack, approach_distance=self.approach_distance
                 )
             except RuntimeError as e:
-                if "arm" in str(e): # don't count moveit related exceptions as "side not available"
+                if "arm" in str(
+                    e
+                ):  # don't count moveit related exceptions as "side not available"
                     raise e
                 sides_not_available += 1
                 logging.warning(e)

--- a/rai_app/environment/scene_manager.py
+++ b/rai_app/environment/scene_manager.py
@@ -323,7 +323,7 @@ class SceneManager:
             ROS2Message(payload={}),
             target="/reset_simulation",
             msg_type="simulation_interfaces/srv/ResetSimulation",
-            timeout_sec=10.0
+            timeout_sec=10.0,
         )
 
     def move_entity(

--- a/rai_app/environment/scene_manager.py
+++ b/rai_app/environment/scene_manager.py
@@ -317,6 +317,15 @@ class SceneManager:
                 timeout_sec=3.0,
             )
 
+    def reset_simulation(self):
+        wait_for_ros2_services(self.connector, ["/reset_simulation"])
+        self.connector.call_service(
+            ROS2Message(payload={}),
+            target="/reset_simulation",
+            msg_type="simulation_interfaces/srv/ResetSimulation",
+            timeout_sec=10.0
+        )
+
     def move_entity(
         self,
         entity_name,

--- a/tests/test_housekeep.py
+++ b/tests/test_housekeep.py
@@ -79,4 +79,5 @@ def test_single_box_housekeeping(
         result = housekeep_tool._run(rack)
         assert "successfully" in result, f"HouseKeepTool failed: {result}"
     except Exception as e:
+        scene_manager.reset_simulation()
         pytest.fail(f"HouseKeepTool failed: {e}")


### PR DESCRIPTION
Housekeep tool would ignore moveit errors and treat them as "side not available" (for housekeeping), making failing tests pass.

When a housekeep test fails (probably because of a moveit error, or a human getting deadlocked in the way of the robot), it makes no sense to run the next test, because it will also fail. So a simulation reset is triggered that will put the robot and human back into a valid configuration.