### PR TITLE
test: Remove humanworker from scene when testing

### DIFF
--- a/project_gems/LevelGem/Assets/Scripts/SelfDestructService.scriptcanvas
+++ b/project_gems/LevelGem/Assets/Scripts/SelfDestructService.scriptcanvas
@@ -1,0 +1,1374 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "ScriptCanvasData",
+    "ClassData": {
+        "m_scriptCanvas": {
+            "Id": {
+                "id": 234656730974139
+            },
+            "Name": "Script Canvas Graph",
+            "Components": {
+                "Component_[11004369901032857428]": {
+                    "$type": "EditorGraphVariableManagerComponent",
+                    "Id": 11004369901032857428,
+                    "m_variableData": {
+                        "m_nameVariableMap": [
+                            {
+                                "Key": {
+                                    "m_id": "{66D06E5B-02F6-4828-91D0-3AE55145C1C2}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 5
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "AZStd::string",
+                                        "value": "/self_destruct"
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{66D06E5B-02F6-4828-91D0-3AE55145C1C2}"
+                                    },
+                                    "VariableName": "Topic name",
+                                    "InitialValueSource": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                "Component_[15917856222319056077]": {
+                    "$type": "EditorGraph",
+                    "Id": 15917856222319056077,
+                    "m_graphData": {
+                        "m_nodes": [
+                            {
+                                "Id": {
+                                    "id": 234661025941435
+                                },
+                                "Name": "SC-Node(DestroyGameEntityAndDescendants)",
+                                "Components": {
+                                    "Component_[12243959631097307072]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 12243959631097307072,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{1FE102FA-38E4-4B3D-845D-385A5C7AA043}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{752279DF-14C6-4AF8-94E6-D91535B4D81A}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E9FE2E72-1C80-4FC0-B0CE-A9D08FC3555A}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 2901262558
+                                                },
+                                                "label": "Entity Id"
+                                            }
+                                        ],
+                                        "methodType": 0,
+                                        "methodName": "DestroyGameEntityAndDescendants",
+                                        "className": "GameEntityContextRequestBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{1FE102FA-38E4-4B3D-845D-385A5C7AA043}"
+                                            }
+                                        ],
+                                        "prettyClassName": "GameEntityContextRequestBus"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 234665320908731
+                                },
+                                "Name": "SC-Node(Start)",
+                                "Components": {
+                                    "Component_[14304628459609262687]": {
+                                        "$type": "Start",
+                                        "Id": 14304628459609262687,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{E51A03F4-FC70-4DB2-9E5C-CD54B09AE380}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled when the entity that owns this graph is fully activated.",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Id": 14304628459609262687
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 234669615876027
+                                },
+                                "Name": "EBusEventHandler",
+                                "Components": {
+                                    "Component_[3125437101086018405]": {
+                                        "$type": "EBusEventHandler",
+                                        "Id": 3125437101086018405,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{4E50F66A-50C8-4EB3-BA82-BBDA1CAD8282}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Connect",
+                                                "toolTip": "Connect this event handler to the specified entity.",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F494F908-380F-439F-8210-AE2DB1C21C0B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Disconnect",
+                                                "toolTip": "Disconnect this event handler.",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{5CEC9510-F25D-4590-8ABD-420E22E256E7}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "OnConnected",
+                                                "toolTip": "Signaled when a connection has taken place.",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{8093B768-17EC-448C-A0DD-64E8CA5DFB79}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "OnDisconnected",
+                                                "toolTip": "Signaled when this event handler is disconnected.",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{166FF255-D533-442A-AA96-DF389AD96DBC}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "OnFailure",
+                                                "toolTip": "Signaled when it is not possible to connect this handler.",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EAD94009-7EC1-4264-A24A-4E4A28D56D8D}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Source",
+                                                "toolTip": "ID used to connect on a specific Event address (Type: AZStd::basic_string<char, AZStd::char_traits<char>, allocator>)",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{66D06E5B-02F6-4828-91D0-3AE55145C1C2}"
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EC132D3C-9C0D-455A-B24C-F9B90DD40D17}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Boolean",
+                                                "DisplayDataType": {
+                                                    "m_type": 0
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{76CF8273-0984-4A94-80A1-BA0A2E4E81A4}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnStdMsgBool",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{30E165CA-1F0E-4B4E-AB90-F4ECCCDFF303}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Boolean",
+                                                "DisplayDataType": {
+                                                    "m_type": 0
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{83CF56E6-325A-466F-866C-B24F907DAE61}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Boolean",
+                                                "DisplayDataType": {
+                                                    "m_type": 0
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{CBB23E6F-D821-46C2-B59C-77BC073597C0}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Boolean",
+                                                "DisplayDataType": {
+                                                    "m_type": 0
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E7DE1CDC-54D3-44D3-813B-B9F76F8783BA}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Boolean",
+                                                "DisplayDataType": {
+                                                    "m_type": 0
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E42C5570-78CF-48F0-93EC-BEB8AFD83D21}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{1511482D-6212-4BA9-A2C7-2B731E2B8911}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{0335E81C-37DC-4CA1-927D-98FF71D52B0A}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{2EC5BDD2-07AB-4D41-B4BA-666B8C2A01DF}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{2B00C8CE-4D41-468B-A35C-17EC55EDF38E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnSensorMsgJoy",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{7ED8C4DA-C26A-4033-92C4-3C708BA10A92}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "String",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{2E154AE4-3D59-4D73-9714-CD87DDD8F796}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Transform",
+                                                "DisplayDataType": {
+                                                    "m_type": 7
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{10E0E169-0D45-47C6-B3C1-85E1EDFE8038}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnGeometryMsgPoseStamped",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{CE830311-8432-4E4F-A539-12C781F6C41B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "String",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A5520928-1C98-44B1-A93F-96F28D7714DA}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnStdMsgString",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{0A03CEEA-4FEB-44B7-8DBF-E05347FD3404}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{9F1F6F24-D294-4652-B178-DBA53F8F70D4}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnStdMsgFloat32",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{DF334EBA-149E-4DDF-8958-4DF9E6BE3F27}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{B53AFE9F-A51A-4D33-987A-6FAC273220DD}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnStdMsgUInt32",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{378C2209-E81E-421D-9F61-F88820376156}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{365C6DDC-6F42-469E-921C-D1192E5120A8}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnStdMsgInt32",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{1791AB0E-5064-4718-875A-66C2CEDE6FB9}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Vector3",
+                                                "DisplayDataType": {
+                                                    "m_type": 8
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{000546A9-C00D-45C2-BF54-3926852406DA}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnGeometryMsgVector3",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{4DA16DA9-E4AB-4ADE-9AF0-1055815C760F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Quaternion",
+                                                "DisplayDataType": {
+                                                    "m_type": 6
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D84B2687-C2C3-4266-9BCB-E2CDE28091F3}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnGeometryMsgQuaternion",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{63E71F30-0A38-45A0-BCE1-99657458CFCB}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Transform",
+                                                "DisplayDataType": {
+                                                    "m_type": 7
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{81E4C961-145A-4CC6-8300-AEDB490F672F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ExecutionSlot:OnGeometryMsgTransform",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "AZStd::string",
+                                                "value": ""
+                                            }
+                                        ],
+                                        "Id": 3125437101086018405,
+                                        "m_eventMap": [
+                                            {
+                                                "Key": {
+                                                    "Value": 296352513
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnStdMsgFloat32",
+                                                    "m_eventId": {
+                                                        "Value": 296352513
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{9F1F6F24-D294-4652-B178-DBA53F8F70D4}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{0A03CEEA-4FEB-44B7-8DBF-E05347FD3404}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 1
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 363245998
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnGeometryMsgQuaternion",
+                                                    "m_eventId": {
+                                                        "Value": 363245998
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{D84B2687-C2C3-4266-9BCB-E2CDE28091F3}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{4DA16DA9-E4AB-4ADE-9AF0-1055815C760F}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 1
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 799201559
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnGeometryMsgVector3",
+                                                    "m_eventId": {
+                                                        "Value": 799201559
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{000546A9-C00D-45C2-BF54-3926852406DA}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{1791AB0E-5064-4718-875A-66C2CEDE6FB9}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 1
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 1097367768
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnGeometryMsgPoseStamped",
+                                                    "m_eventId": {
+                                                        "Value": 1097367768
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{10E0E169-0D45-47C6-B3C1-85E1EDFE8038}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{7ED8C4DA-C26A-4033-92C4-3C708BA10A92}"
+                                                        },
+                                                        {
+                                                            "m_id": "{2E154AE4-3D59-4D73-9714-CD87DDD8F796}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 2
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 2153135392
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnStdMsgUInt32",
+                                                    "m_eventId": {
+                                                        "Value": 2153135392
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{B53AFE9F-A51A-4D33-987A-6FAC273220DD}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{DF334EBA-149E-4DDF-8958-4DF9E6BE3F27}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 1
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 3562722152
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnStdMsgString",
+                                                    "m_eventId": {
+                                                        "Value": 3562722152
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{A5520928-1C98-44B1-A93F-96F28D7714DA}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{CE830311-8432-4E4F-A539-12C781F6C41B}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 1
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 3684301929
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnSensorMsgJoy",
+                                                    "m_eventId": {
+                                                        "Value": 3684301929
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{2B00C8CE-4D41-468B-A35C-17EC55EDF38E}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{30E165CA-1F0E-4B4E-AB90-F4ECCCDFF303}"
+                                                        },
+                                                        {
+                                                            "m_id": "{83CF56E6-325A-466F-866C-B24F907DAE61}"
+                                                        },
+                                                        {
+                                                            "m_id": "{CBB23E6F-D821-46C2-B59C-77BC073597C0}"
+                                                        },
+                                                        {
+                                                            "m_id": "{E7DE1CDC-54D3-44D3-813B-B9F76F8783BA}"
+                                                        },
+                                                        {
+                                                            "m_id": "{E42C5570-78CF-48F0-93EC-BEB8AFD83D21}"
+                                                        },
+                                                        {
+                                                            "m_id": "{1511482D-6212-4BA9-A2C7-2B731E2B8911}"
+                                                        },
+                                                        {
+                                                            "m_id": "{0335E81C-37DC-4CA1-927D-98FF71D52B0A}"
+                                                        },
+                                                        {
+                                                            "m_id": "{2EC5BDD2-07AB-4D41-B4BA-666B8C2A01DF}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 8
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 3715700297
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnStdMsgInt32",
+                                                    "m_eventId": {
+                                                        "Value": 3715700297
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{365C6DDC-6F42-469E-921C-D1192E5120A8}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{378C2209-E81E-421D-9F61-F88820376156}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 1
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 3888683221
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnGeometryMsgTransform",
+                                                    "m_eventId": {
+                                                        "Value": 3888683221
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{81E4C961-145A-4CC6-8300-AEDB490F672F}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{63E71F30-0A38-45A0-BCE1-99657458CFCB}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 1
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "Value": 4280392370
+                                                },
+                                                "Value": {
+                                                    "m_eventName": "OnStdMsgBool",
+                                                    "m_eventId": {
+                                                        "Value": 4280392370
+                                                    },
+                                                    "m_eventSlotId": {
+                                                        "m_id": "{76CF8273-0984-4A94-80A1-BA0A2E4E81A4}"
+                                                    },
+                                                    "m_parameterSlotIds": [
+                                                        {
+                                                            "m_id": "{EC132D3C-9C0D-455A-B24C-F9B90DD40D17}"
+                                                        }
+                                                    ],
+                                                    "m_numExpectedArguments": 1
+                                                }
+                                            }
+                                        ],
+                                        "m_ebusName": "SubscriberNotificationsBus",
+                                        "m_busId": {
+                                            "Value": 2754838993
+                                        },
+                                        "m_autoConnectToGraphOwner": false
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 234673910843323
+                                },
+                                "Name": "SC-Node(SubscribeToStdMsgInt32)",
+                                "Components": {
+                                    "Component_[5098215856723174772]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 5098215856723174772,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{0B001E09-EBE6-4E07-A47A-557718CF1C11}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Topic",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{66D06E5B-02F6-4828-91D0-3AE55145C1C2}"
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{FC3DBD3F-CE4F-4051-80B9-A4DAF3B9FD9D}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{1DDC3DAE-C57C-44C4-A4DE-99628123DCF3}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "AZStd::string",
+                                                "value": "",
+                                                "label": "Topic"
+                                            }
+                                        ],
+                                        "methodType": 0,
+                                        "methodName": "SubscribeToStdMsgInt32",
+                                        "className": "SubscriberRequestBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{0B001E09-EBE6-4E07-A47A-557718CF1C11}"
+                                            }
+                                        ],
+                                        "prettyClassName": "SubscriberRequestBus"
+                                    }
+                                }
+                            }
+                        ],
+                        "m_connections": [
+                            {
+                                "Id": {
+                                    "id": 234678205810619
+                                },
+                                "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(SubscribeToStdMsgInt32: In)",
+                                "Components": {
+                                    "Component_[2797782533709732686]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 2797782533709732686,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 234665320908731
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E51A03F4-FC70-4DB2-9E5C-CD54B09AE380}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 234673910843323
+                                            },
+                                            "slotId": {
+                                                "m_id": "{FC3DBD3F-CE4F-4051-80B9-A4DAF3B9FD9D}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 234682500777915
+                                },
+                                "Name": "srcEndpoint=(SubscribeToStdMsgInt32: Out), destEndpoint=(SubscriberNotificationsBus Handler: Connect)",
+                                "Components": {
+                                    "Component_[5631604687428376269]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 5631604687428376269,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 234673910843323
+                                            },
+                                            "slotId": {
+                                                "m_id": "{1DDC3DAE-C57C-44C4-A4DE-99628123DCF3}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 234669615876027
+                                            },
+                                            "slotId": {
+                                                "m_id": "{4E50F66A-50C8-4EB3-BA82-BBDA1CAD8282}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 234686795745211
+                                },
+                                "Name": "srcEndpoint=(SubscriberNotificationsBus Handler: ExecutionSlot:OnStdMsgInt32), destEndpoint=(DestroyGameEntityAndDescendants: In)",
+                                "Components": {
+                                    "Component_[5907836249590164752]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 5907836249590164752,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 234669615876027
+                                            },
+                                            "slotId": {
+                                                "m_id": "{365C6DDC-6F42-469E-921C-D1192E5120A8}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 234661025941435
+                                            },
+                                            "slotId": {
+                                                "m_id": "{752279DF-14C6-4AF8-94E6-D91535B4D81A}"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "versionData": {
+                        "_grammarVersion": 1,
+                        "_runtimeVersion": 1,
+                        "_fileVersion": 1
+                    },
+                    "m_variableCounter": 4,
+                    "GraphCanvasData": [
+                        {
+                            "Key": {
+                                "id": 234656730974139
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
+                                        "$type": "SceneComponentSaveData",
+                                        "ViewParams": {
+                                            "Scale": 0.8942321833165814,
+                                            "AnchorX": -1334.10546875,
+                                            "AnchorY": 289.6339416503906
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 234661025941435
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -220.0,
+                                            600.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{FDCF29C4-CA5A-43A6-9D79-AC4C271D44DF}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 234665320908731
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -1060.0,
+                                            600.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{5329542B-8E38-4DC0-9D20-5E62858571B0}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 234669615876027
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -560.0,
+                                            580.0
+                                        ]
+                                    },
+                                    "{9E81C95F-89C0-4476-8E82-63CCC4E52E04}": {
+                                        "$type": "EBusHandlerNodeDescriptorSaveData",
+                                        "EventIds": [
+                                            {
+                                                "Value": 3715700297
+                                            }
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{ECC26D91-79EA-431A-814F-357CE6A26E74}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 234673910843323
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -880.0,
+                                            600.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{930E6949-09D5-4B2F-B4B2-CA12969F345A}"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "StatisticsHelper": {
+                        "InstanceCounter": [
+                            {
+                                "Key": 4199610336680704683,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 5842117344301549445,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 13774516197139363424,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 13774516597655171881,
+                                "Value": 1
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rai_app/environment/scene_manager.py
+++ b/rai_app/environment/scene_manager.py
@@ -31,6 +31,7 @@ from rai.communication.ros2 import (
     ROS2Message,
     wait_for_ros2_services,
 )
+from rclpy.qos import qos_profile_best_available
 from rosidl_runtime_py.convert import message_to_ordereddict
 from simulation_interfaces.msg import EntityState, Result
 from simulation_interfaces.msg import SpawnEntity as SpawnEntityMsg
@@ -389,6 +390,14 @@ class SceneManager:
             target="/reset_simulation",
             msg_type="simulation_interfaces/srv/ResetSimulation",
             timeout_sec=10.0,
+        )
+
+    def remove_humanworker(self):
+        self.connector.send_message(
+            ROS2Message(payload={"data": 0}),
+            target="/remove_humanworker",
+            msg_type="std_msgs/msg/Int32",
+            qos_profile=qos_profile_best_available,
         )
 
     def move_entity(

--- a/rai_app/environment/scene_manager.py
+++ b/rai_app/environment/scene_manager.py
@@ -17,6 +17,7 @@ import argparse
 import copy
 import math
 import random
+import time
 import uuid
 from enum import Enum
 from operator import attrgetter
@@ -31,7 +32,6 @@ from rai.communication.ros2 import (
     ROS2Message,
     wait_for_ros2_services,
 )
-from rclpy.qos import qos_profile_best_available
 from rosidl_runtime_py.convert import message_to_ordereddict
 from simulation_interfaces.msg import EntityState, Result
 from simulation_interfaces.msg import SpawnEntity as SpawnEntityMsg
@@ -391,13 +391,19 @@ class SceneManager:
             msg_type="simulation_interfaces/srv/ResetSimulation",
             timeout_sec=10.0,
         )
+        time.sleep(3.0)
 
     def remove_humanworker(self):
+        while True:  # wait for the topic to appear so the message will be recieved.
+            time.sleep(1.0)
+            topics = [tup[0] for tup in self.connector.get_topics_names_and_types()]
+            if "/remove_humanworker" in topics:
+                break
+
         self.connector.send_message(
             ROS2Message(payload={"data": 0}),
             target="/remove_humanworker",
             msg_type="std_msgs/msg/Int32",
-            qos_profile=qos_profile_best_available,
         )
 
     def move_entity(

--- a/sim/Levels/DemoLevel/DemoLevel.prefab
+++ b/sim/Levels/DemoLevel/DemoLevel.prefab
@@ -220,6 +220,88 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
                     "value": "../Entity_[1146574390643]"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[211640413054656]/Components/EditorScriptCanvasComponent",
+                    "value": {
+                        "$type": "EditorScriptCanvasComponent",
+                        "Id": 10872500690270102334,
+                        "configuration": {
+                            "sourceHandle": {
+                                "id": "{C75ADE47-8B42-5008-9E83-7B097578841C}",
+                                "path": "Assets/Scripts/SelfDestructService.scriptcanvas"
+                            },
+                            "sourceName": "SelfDestructService.scriptcanvas",
+                            "propertyOverrides": {
+                                "source": {
+                                    "id": "{C75ADE47-8B42-5008-9E83-7B097578841C}",
+                                    "path": "Assets/Scripts/SelfDestructService.scriptcanvas"
+                                },
+                                "variables": [
+                                    {
+                                        "Datum": {
+                                            "isOverloadedStorage": false,
+                                            "scriptCanvasType": {
+                                                "m_type": 5,
+                                                "m_azType": "{00000000-0000-0000-0000-000000000000}"
+                                            },
+                                            "isNullPointer": false,
+                                            "$type": "AZStd::string",
+                                            "value": "/self_destruct",
+                                            "label": ""
+                                        },
+                                        "InputControlVisibility": {
+                                            "Value": 2755429085
+                                        },
+                                        "ExposureCategory": "",
+                                        "SortPriority": -1,
+                                        "ReplicaNetProps": {
+                                            "m_isSynchronized": false
+                                        },
+                                        "VariableId": {
+                                            "m_id": "{66D06E5B-02F6-4828-91D0-3AE55145C1C2}"
+                                        },
+                                        "VariableName": "Topic name",
+                                        "Scope": 0,
+                                        "InitialValueSource": 1
+                                    }
+                                ],
+                                "entityId": [],
+                                "overrides": [
+                                    {
+                                        "Datum": {
+                                            "isOverloadedStorage": false,
+                                            "scriptCanvasType": {
+                                                "m_type": 5,
+                                                "m_azType": "{00000000-0000-0000-0000-000000000000}"
+                                            },
+                                            "isNullPointer": false,
+                                            "$type": "AZStd::string",
+                                            "value": "/remove_humanworker",
+                                            "label": ""
+                                        },
+                                        "InputControlVisibility": {
+                                            "Value": 850104567
+                                        },
+                                        "ExposureCategory": "",
+                                        "SortPriority": -1,
+                                        "ReplicaNetProps": {
+                                            "m_isSynchronized": false
+                                        },
+                                        "VariableId": {
+                                            "m_id": "{66D06E5B-02F6-4828-91D0-3AE55145C1C2}"
+                                        },
+                                        "VariableName": "Topic name",
+                                        "Scope": 0,
+                                        "InitialValueSource": 1
+                                    }
+                                ],
+                                "overridesUnused": [],
+                                "dependencies": []
+                            }
+                        }
+                    }
                 }
             ]
         },
@@ -432,7 +514,7 @@
                                 "Transform Data": {
                                     "Translate": [
                                         -0.6043558120727539,
-                                        -0.09543037414550781,
+                                        -0.0954303741455078,
                                         0.5401168465614319
                                     ],
                                     "Rotate": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,11 +37,13 @@ def connector():
 
 @pytest.fixture(scope="session")
 def scene_manager(connector: ROS2Connector):
-    return SceneManager(
+    manager = SceneManager(
         slots_file="scripts/resources/slots.csv",
         spawnables_file="scripts/resources/spawnables.csv",
         connector=connector,
     )
+    manager.remove_humanworker()
+    return manager
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_housekeep.py
+++ b/tests/test_housekeep.py
@@ -80,4 +80,5 @@ def test_single_box_housekeeping(
         assert "successfully" in result, f"HouseKeepTool failed: {result}"
     except Exception as e:
         scene_manager.reset_simulation()
+        scene_manager.remove_humanworker()
         pytest.fail(f"HouseKeepTool failed: {e}")


### PR DESCRIPTION
Added a simple script that will destroy the humanworker after receiving a message from a topic.
<img width="1209" height="385" alt="image" src="https://github.com/user-attachments/assets/2de7f9d5-40c1-44ce-b53a-ae93c0efeea1" />

Added code to send the message before initializing scene_manager fixture in tests.