### PR TITLE
build: install `tmux` with `apt`

### DIFF
--- a/docs/setup_single_machine.md
+++ b/docs/setup_single_machine.md
@@ -28,7 +28,7 @@ sudo apt install git git-lfs python3-vcstool ninja-build \
     libglu1-mesa-dev libxcb-randr0-dev libxcb-xinerama0 libxcb-xinput0 \
     libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev \
     libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev \
-    mesa-common-dev libunwind-dev libzstd-dev tix
+    mesa-common-dev libunwind-dev libzstd-dev tix tmux
 ```
 
 #### Install pixi


### PR DESCRIPTION
`pixi` uses `tmux` to deploy jobs in background sessions, but setup instructions were 
missing `tmux` installation. This PR adds that.
